### PR TITLE
Oreimo Season 2 fix

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -25325,6 +25325,9 @@
   </anime>
   <anime anidbid="9134" tvdbid="194961" defaulttvdbseason="2" tmdbid="" imdbid="">
     <name>Ore no Imouto ga Konna ni Kawaii Wake ga Nai.</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="2">;1-14;2-15;3-16;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="9139" tvdbid="" defaulttvdbseason="" tmdbid="" imdbid="">
     <name>Kubire 3 Shimai</name>


### PR DESCRIPTION
Oreimo (Ore no Imouto ga Konna ni Kawaii Wake ga Nai. - a9134) Season 2 mapping
fixes
Special 1 on AniDB is S02E14 on TVDB
Special 2 on AniDB is S02E15 on TVDB
Special 3 on AniDB is S02E16 on TVDB
