### PR TITLE
Fixes for Ookami Shoujo and Little Witch Academia 1 and 2

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -27304,7 +27304,7 @@
       <mapping anidbseason="1" tvdbseason="0">;1-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="9971" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="9971" tvdbid="259863" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Little Witch Academia: The Enchanted Parade</name>
   </anime>
   <anime anidbid="9973" tvdbid="278127" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -25391,7 +25391,7 @@
   <anime anidbid="9250" tvdbid="259863" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Little Witch Academia</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="3">;1-2;</mapping>
+      <mapping anidbseason="1" tvdbseason="3">;1-3;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="9251" tvdbid="259863" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -28791,7 +28791,7 @@
   <anime anidbid="10588" tvdbid="283611" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ninja Slayer from Animation</name>
   </anime>
-  <anime anidbid="10589" tvdbid="284755" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="10589" tvdbid="284563" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ookami Shoujo to Kuro Ouji</name>
   </anime>
   <anime anidbid="10590" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
The current tvdbid that's filled in for Ookami Shoujo seems to be an invalid one, no tv series exists with that id. I've changed it to the correct one now.

For Little Witch Academia the episode mapping was incorrect, I fixed it so it maps to episode 3x03 now. I hope I mapped it correctly. 

For The Enchanted Parade I added the same tvdbid as Little Witch Academia, where it seems to be considered a special. It's episode 1 of the specials so no episode mapping seemed necessary.