### PR TITLE
Additional special episode mapping for Clannad and Clannad: After Story

### DIFF
--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -14344,6 +14344,7 @@
     <name>Clannad</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="1">;1-23;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;2-2;</mapping>
     </mapping-list>
     <before>;1-23;</before>
   </anime>
@@ -15851,6 +15852,7 @@
     <name>Clannad: After Story</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="2">;1-23;2-24;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;3-3;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="5842" tvdbid="83263" defaulttvdbseason="1">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -14428,6 +14428,7 @@
     <name>Clannad</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="1">;1-23;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;2-2;</mapping>
     </mapping-list>
     <before>;1-23;</before>
   </anime>
@@ -15944,6 +15945,7 @@
     <name>Clannad: After Story</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="2">;1-23;2-24;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;3-3;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="5842" tvdbid="83263" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list.xml
+++ b/anime-list.xml
@@ -12340,6 +12340,7 @@
     <name>Clannad</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="1">;1-23;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;2-2;</mapping>
     </mapping-list>
     <before>;1-23;</before>
   </anime>
@@ -13574,6 +13575,7 @@
     <name>Clannad: After Story</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="2">;1-23;2-24;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;3-3;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="5842" tvdbid="83263" defaulttvdbseason="1">


### PR DESCRIPTION
While testing out @fuzeman 's new Plex -> Trakt.tv scrobbler with anime-list support I came across a couple of Clannad and Clannad: After Story special episodes which were missing a mapping, and thus the anidb special was mapped on to a TVDB regular episode by mistake. 

I've updated the lists in this PR following the instructions, but as this is the first time i've edited these lists i'd appreciate it if you could double check i've done this correctly!

Many thanks for creating and curating these lists.