### PR TITLE
s.CRY.ed: specials fixes

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -224,6 +224,9 @@
   </anime>
   <anime anidbid="47" tvdbid="78953" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Scryed</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
+    </mapping-list>
     <supplemental-info>
       <studio>Sunrise</studio>
     </supplemental-info>
@@ -22886,6 +22889,9 @@
   </anime>
   <anime anidbid="8342" tvdbid="78953" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="unknown">
     <name>Scryed Alteration</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
+    </mapping-list>
     <supplemental-info>
       <studio>Sunrise</studio>
     </supplemental-info>


### PR DESCRIPTION
Null-mapping specials from aid 47 that conflict with its later OVAs in aid 8342. Also null-mapping specials from aid 8342 that would fallback map unto itself.