### PR TITLE
Card Captor Sakura: mapping fixes

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -462,7 +462,7 @@
   <anime anidbid="102" tvdbid="70668" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
     <name>Cardcaptor Sakura</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-3;2-4;3-5;4-6;5-6;7-6;8-6;9-6;10-6;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-3;2-4;3-5;4-0;5-0;6-0;7-0;8-0;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="103" tvdbid="74462" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -2077,6 +2077,7 @@
   <anime anidbid="514" tvdbid="70668" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0301083">
     <name>Gekijouban Cardcaptor Sakura: Fuuin Sareta Card</name>
     <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-6;</mapping>
       <mapping anidbseason="1" tvdbseason="0">;1-2;2-2;3-2;</mapping>
     </mapping-list>
   </anime>
@@ -33069,6 +33070,9 @@
   </anime>
   <anime anidbid="12140" tvdbid="70668" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">
     <name>Cardcaptor Sakura: Clear Card Hen</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-8;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="12141" tvdbid="299742" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Starmyu (2017)</name>


### PR DESCRIPTION
With the release of Clear Card Hen, a bunch of shuffling happened on TheTVDB. This shuffles stuff back in places and maps previously unmapped episodes.