### PR TITLE
Seishuuheiki Kanojo: specials mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -536,6 +536,9 @@
   </anime>
   <anime anidbid="113" tvdbid="79798" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Saishuuheiki Kanojo</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">1-3;2-0;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="114" tvdbid="79520" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ima, Soko ni Iru Boku</name>


### PR DESCRIPTION
Some shuffling happened on TheTVDB. aid 2700 is now s0e1 and s0e2. We're mapping special #1 for aid 113 to s0e3 where it now has been shuffled to.