### PR TITLE
Magic Knight Rayearth: specials fixes

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -585,7 +585,7 @@
   <anime anidbid="127" tvdbid="71634" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
     <name>Magic Knight Rayearth</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;3-0;4-0;</mapping>
+      <mapping anidbseason="0" tvdbseason="0" start="1" end="4" offset="4">;5-0;</mapping>
     </mapping-list>
     <supplemental-info replace="true">
       <studio>TMS Entertainment</studio>


### PR DESCRIPTION
OVA at aid 424 was shuffled to the front and omakes are now on TheTVDB. This maps this change.