### PR TITLE
Add useragent string to curl

### DIFF
--- a/update.bat
+++ b/update.bat
@@ -1,6 +1,6 @@
 @echo off
 
-curl -o animetitles.xml --compressed http://anidb.net/api/animetitles.xml.gz
+curl -A Scudlee/anime-lists -o animetitles.xml --compressed http://anidb.net/api/anime-titles.xml.gz
 
 xsltproc -o animetitles.xml transforms/sort-animetitles.xsl animetitles.xml
 xsltproc -o anime-list-master.xml transforms/update-anime-list-master.xsl animetitles.xml

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-curl -o animetitles.xml --compressed http://anidb.net/api/animetitles.xml.gz
+curl -A Scudlee/anime-lists -o animetitles.xml --compressed http://anidb.net/api/anime-titles.xml.gz
 
 xsltproc -o animetitles.xml transforms/sort-animetitles.xsl animetitles.xml
 xsltproc -o anime-list-master.xml transforms/update-anime-list-master.xsl animetitles.xml


### PR DESCRIPTION
Anidb recently changed policy on the animetitles.xml access and requires
that the requesting project is announced in the useragent string.