### PR TITLE
Fixes for a11974 and a13, mapping for a13901, minor formatting

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -3511,7 +3511,7 @@
   <anime anidbid="906" tvdbid="81472" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="tt0142234">
     <name>Dragon Ball Z: Super Senshi Gekiha!! Katsu no wa Ore Da</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;;2-11;3-11;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;2-11;3-11;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="907" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -67,7 +67,7 @@
   <anime anidbid="13" tvdbid="78947" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Noir</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;2-6;3-7;4-5;101-1;102-2;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="14" tvdbid="72720" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -3502,16 +3502,16 @@
   <anime anidbid="904" tvdbid="73988" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>The Big O</name>
   </anime>
-  <anime anidbid="905" tvdbid="81472" defaulttvdbseason="0" episodeoffset="7" tmdbid="" imdbid="tt0142242">
+  <anime anidbid="905" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142242">
     <name>Dragon Ball Z: Moetsukiro!! Nessen, Ressen, Chougekisen</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;2-8;3-8;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-8;2-8;3-8;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="906" tvdbid="81472" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="tt0142234">
+  <anime anidbid="906" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142234">
     <name>Dragon Ball Z: Super Senshi Gekiha!! Katsu no wa Ore Da</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;2-11;3-11;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-11;2-11;3-11;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="907" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -3979,10 +3979,10 @@
       <studio>Toei Animation</studio>
     </supplemental-info>
   </anime>
-  <anime anidbid="1044" tvdbid="81472" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="tt0142240">
+  <anime anidbid="1044" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142240">
     <name>Dragon Ball Z: Kono Yo de Ichiban Tsuyoi Yatsu</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;2-2;3-2;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-2;2-2;3-2;</mapping>
     </mapping-list>
     <supplemental-info>
       <studio>Toei Animation</studio>
@@ -4064,16 +4064,16 @@
   <anime anidbid="1068" tvdbid="tv special" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt0167006">
     <name>Battle Spirits: Ryuuko no Ken</name>
   </anime>
-  <anime anidbid="1069" tvdbid="81472" defaulttvdbseason="0" episodeoffset="8" tmdbid="" imdbid="tt0142238">
+  <anime anidbid="1069" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142238">
     <name>Dragon Ball Z: Ginga Girigiri!! Bucchigiri no Sugoi Yatsu</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;2-9;3-9;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-9;2-9;3-9;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="1070" tvdbid="81472" defaulttvdbseason="0" episodeoffset="9" tmdbid="" imdbid="tt0285036">
+  <anime anidbid="1070" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0285036">
     <name>Dragon Ball Z: Kiken na Futari! Super Senshi wa Nemurenai</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;2-10;3-10;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-10;2-10;3-10;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="1071" tvdbid="81472" defaulttvdbseason="0" episodeoffset="11" tmdbid="" imdbid="tt0142236">
@@ -7924,11 +7924,8 @@
   <anime anidbid="2336" tvdbid="81472" defaulttvdbseason="0" episodeoffset="13" tmdbid="" imdbid="tt0142245">
     <name>Dragon Ball Z Special: Tatta Hitori no Saishuu Kessen - Freezer ni Idonda Z Senshi Son Gokuu no Chichi</name>
   </anime>
-  <anime anidbid="2337" tvdbid="84045" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt1569361">
+  <anime anidbid="2337" tvdbid="84045" defaulttvdbseason="0" episodeoffset="13" tmdbid="" imdbid="tt1569361">
     <name>Captain Tsubasa: Europa Daikessen</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-14;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="2339" tvdbid="84535" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Sweet Valerian</name>
@@ -8833,11 +8830,8 @@
       <mapping anidbseason="1" tvdbseason="0">;401-17;402-18;403-18;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="2644" tvdbid="81797" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt1018764">
+  <anime anidbid="2644" tvdbid="81797" defaulttvdbseason="0" episodeoffset="12" tmdbid="" imdbid="tt1018764">
     <name>One Piece: Omatsuri Danshaku to Himitsu no Shima</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-13;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="2645" tvdbid="72454" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0965649">
     <name>Meitantei Conan: Juuyonbanme no Target</name>
@@ -17715,7 +17709,7 @@
   <anime anidbid="6517" tvdbid="142601" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Kidou Senshi Gundam Unicorn</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;3-0;4-0;5-0;6-0;7-0;8-0;9-0;10-0;11-0;14-8;15-9;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;3-0;4-0;5-0;6-0;7-0;8-0;9-0;10-0;11-0;12-0;13-0;14-8;15-9;</mapping>
     </mapping-list>
     <supplemental-info>
       <studio>Sunrise</studio>
@@ -32813,7 +32807,7 @@
   <anime anidbid="11972" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Nuwa Chengzhang Riji</name>
   </anime>
-  <anime anidbid="11974" tvdbid="321670" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="11974" tvdbid="321670" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Dungeon ni Deai o Motomeru no wa Machigatte Iru Darouka Gaiden: Sword Oratoria</name>
   </anime>
   <anime anidbid="11975" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -38114,7 +38108,7 @@
   <anime anidbid="13900" tvdbid="345596" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Seishun Buta Yarou wa Bunny Girl Senpai no Yume o Minai</name>
   </anime>
-  <anime anidbid="13901" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13901" tvdbid="272129" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="">
     <name>Strike the Blood III</name>
   </anime>
   <anime anidbid="13902" tvdbid="" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -40595,7 +40589,7 @@
   <anime anidbid="14772" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Baki (Dai Ni Ki)</name>
   </anime>
-  <anime anidbid="14773" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14773" tvdbid="web" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ero Lover</name>
   </anime>
   <anime anidbid="14774" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40727,7 +40721,7 @@
   <anime anidbid="14816" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ling Xie Ji</name>
   </anime>
-  <anime anidbid="14817" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14817" tvdbid="music video" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Daisuki tte Imi Da yo</name>
   </anime>
   <anime anidbid="14818" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -3502,16 +3502,16 @@
   <anime anidbid="904" tvdbid="73988" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>The Big O</name>
   </anime>
-  <anime anidbid="905" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142242">
+  <anime anidbid="905" tvdbid="81472" defaulttvdbseason="0" episodeoffset="7" tmdbid="" imdbid="tt0142242">
     <name>Dragon Ball Z: Moetsukiro!! Nessen, Ressen, Chougekisen</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-8;2-8;3-8;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;2-8;3-8;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="906" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142234">
+  <anime anidbid="906" tvdbid="81472" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="tt0142234">
     <name>Dragon Ball Z: Super Senshi Gekiha!! Katsu no wa Ore Da</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-11;2-11;3-11;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;;2-11;3-11;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="907" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -3979,10 +3979,10 @@
       <studio>Toei Animation</studio>
     </supplemental-info>
   </anime>
-  <anime anidbid="1044" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142240">
+  <anime anidbid="1044" tvdbid="81472" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="tt0142240">
     <name>Dragon Ball Z: Kono Yo de Ichiban Tsuyoi Yatsu</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-2;2-2;3-2;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;2-2;3-2;</mapping>
     </mapping-list>
     <supplemental-info>
       <studio>Toei Animation</studio>
@@ -4064,16 +4064,16 @@
   <anime anidbid="1068" tvdbid="tv special" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt0167006">
     <name>Battle Spirits: Ryuuko no Ken</name>
   </anime>
-  <anime anidbid="1069" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142238">
+  <anime anidbid="1069" tvdbid="81472" defaulttvdbseason="0" episodeoffset="8" tmdbid="" imdbid="tt0142238">
     <name>Dragon Ball Z: Ginga Girigiri!! Bucchigiri no Sugoi Yatsu</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-9;2-9;3-9;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;2-9;3-9;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="1070" tvdbid="81472" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0285036">
+  <anime anidbid="1070" tvdbid="81472" defaulttvdbseason="0" episodeoffset="9" tmdbid="" imdbid="tt0285036">
     <name>Dragon Ball Z: Kiken na Futari! Super Senshi wa Nemurenai</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-10;2-10;3-10;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;2-10;3-10;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="1071" tvdbid="81472" defaulttvdbseason="0" episodeoffset="11" tmdbid="" imdbid="tt0142236">
@@ -8831,7 +8831,7 @@
     </mapping-list>
   </anime>
   <anime anidbid="2644" tvdbid="81797" defaulttvdbseason="0" episodeoffset="12" tmdbid="" imdbid="tt1018764">
-    <name>One Piece: Omatsuri Danshaku to Himitsu no Shima</name>
+    <name>One Piece: Omatsuri Danshaku to Himitsu no Shima</name>		   
   </anime>
   <anime anidbid="2645" tvdbid="72454" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0965649">
     <name>Meitantei Conan: Juuyonbanme no Target</name>


### PR DESCRIPTION
Sword Oratoria (a11974) was mapped to the empty Season 0 of its own TVDB entry. Fixed.
Noir (a13) mapping no longer accurate, as TVDB specials were purged. Fixed.
Strike the Blood III (a13901) mapped.
Formatting changes related to use of offsets vs. mapping lists.