### PR TITLE
Additions - Fall 2019

### DIFF
--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -31059,6 +31059,9 @@
   <anime anidbid="13106" tvdbid="293121" defaulttvdbseason="2">
     <name>Himouto! Umaru-chan R</name>
   </anime>
+  <anime anidbid="13108" tvdbid="283929" defaulttvdbseason="0" episodeoffset="10">
+    <name>Gekijouban Gundam G no Reconguista</name>
+  </anime>
   <anime anidbid="13114" tvdbid="332987" defaulttvdbseason="1">
     <name>Anime-Gataris</name>
   </anime>
@@ -31449,6 +31452,9 @@
   </anime>
   <anime anidbid="13440" tvdbid="353219" defaulttvdbseason="1">
     <name>Gaikotsu Shoten'in Honda-san</name>
+  </anime>
+  <anime anidbid="13441" tvdbid="353455" defaulttvdbseason="1" imdbid="tt11070000">
+    <name>Z/X: Code Reunion</name>
   </anime>
   <anime anidbid="13469" tvdbid="328670" defaulttvdbseason="2">
     <name>Quanzhi Fashi 2</name>
@@ -31886,6 +31892,9 @@
   <anime anidbid="13843" tvdbid="85192" defaulttvdbseason="3">
     <name>Souten no Ken: Regenesis (2018)</name>
   </anime>
+  <anime anidbid="13844" tvdbid="368861" defaulttvdbseason="1" imdbid="tt10882992">
+    <name>Watashi, Nouryoku wa Heikinchi dette Itta yo ne!</name>
+  </anime>
   <anime anidbid="13845" tvdbid="347578" defaulttvdbseason="1">
     <name>Zoids Wild</name>
   </anime>
@@ -31894,6 +31903,9 @@
   </anime>
   <anime anidbid="13848" tvdbid="365720" defaulttvdbseason="1">
     <name>Ahiru no Sora</name>
+  </anime>
+  <anime anidbid="13849" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Dokidoki Little Ooyasan</name>
   </anime>
   <anime anidbid="13859" tvdbid="326337" defaulttvdbseason="3">
     <name>Idolmaster Cinderella Girls Gekijou (2018)</name>
@@ -31953,6 +31965,9 @@
   <anime anidbid="13914" tvdbid="325374" defaulttvdbseason="2">
     <name>Duel Masters!</name>
   </anime>
+  <anime anidbid="13915" tvdbid="ova" defaulttvdbseason="1">
+    <name>Bean Bandit</name>
+  </anime>
   <anime anidbid="13916" tvdbid="347467" defaulttvdbseason="1">
     <name>Muhyo to Roji no Mahouritsu Soudan Jimusho</name>
   </anime>
@@ -31964,6 +31979,9 @@
   </anime>
   <anime anidbid="13923" tvdbid="345100" defaulttvdbseason="1">
     <name>Double Decker! Doug &amp; Kirill</name>
+  </anime>
+  <anime anidbid="13924" tvdbid="movie" defaulttvdbseason="1" imdbid="tt8816016">
+    <name>Black Fox</name>
   </anime>
   <anime anidbid="13925" tvdbid="351751" defaulttvdbseason="1">
     <name>Irozuku Sekai no Ashita kara</name>
@@ -32067,11 +32085,17 @@
   <anime anidbid="14039" tvdbid="293647" defaulttvdbseason="5">
     <name>Ame-iro Cocoa: Side G</name>
   </anime>
+  <anime anidbid="14041" tvdbid="movie" defaulttvdbseason="1" tmdbid="6356813">
+    <name>Kimi dake ni Motetainda.</name>
+  </anime>
   <anime anidbid="14042" tvdbid="142601" defaulttvdbseason="0" episodeoffset="9">
     <name>Kidou Senshi Gundam Narrative</name>
   </anime>
   <anime anidbid="14044" tvdbid="348719" defaulttvdbseason="1">
     <name>Aguu: Tensai Ningyou</name>
+  </anime>
+  <anime anidbid="14047" tvdbid="250022" defaulttvdbseason="0" episodeoffset="9">
+    <name>Yuru Yuri Ten</name>
   </anime>
   <anime anidbid="14049" tvdbid="320002" defaulttvdbseason="0" episodeoffset="1">
     <name>Pastel Life</name>
@@ -32283,6 +32307,9 @@
   <anime anidbid="14237" tvdbid="353579" defaulttvdbseason="1">
     <name>Ken En Ken: Aoki Kagayaki</name>
   </anime>
+  <anime anidbid="14238" tvdbid="353666" defaulttvdbseason="1" imdbid="tt9525238">
+    <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
+  </anime>
   <anime anidbid="14241" tvdbid="353244" defaulttvdbseason="1">
     <name>Okoshiyasu, Chitose-chan</name>
   </anime>
@@ -32361,6 +32388,9 @@
   <anime anidbid="14396" tvdbid="367277" defaulttvdbseason="1">
     <name>Azur Lane the Animation</name>
   </anime>
+  <anime anidbid="14398" tvdbid="361439" defaulttvdbseason="1" tmdbid="93818">
+    <name>Stand My Heroes: Piece of Truth</name>
+  </anime>
   <anime anidbid="14399" tvdbid="hentai" defaulttvdbseason="1">
     <name>Rape Gouhouka!!!</name>
   </anime>
@@ -32372,6 +32402,9 @@
   </anime>
   <anime anidbid="14406" tvdbid="281253" defaulttvdbseason="0">
     <name>Majimoji Rurumo: Kanketsuhen</name>
+  </anime>
+  <anime anidbid="14410" tvdbid="368366" defaulttvdbseason="1" imdbid="tt11033998">
+    <name>Chuubyou Gekihatsu Boy</name>
   </anime>
   <anime anidbid="14412" tvdbid="353608" defaulttvdbseason="1">
     <name>Otona no Bouguya-san</name>
@@ -32406,8 +32439,14 @@
   <anime anidbid="14441" tvdbid="114921" defaulttvdbseason="3">
     <name>Toaru Kagaku no Railgun T</name>
   </anime>
+  <anime anidbid="14442" tvdbid="368862" defaulttvdbseason="1" imdbid="tt10883006">
+    <name>Ore o Suki na no wa Omae Dake ka yo</name>
+  </anime>
   <anime anidbid="14444" tvdbid="267440" defaulttvdbseason="3" episodeoffset="12">
     <name>Shingeki no Kyojin Season 3 (2019)</name>
+  </anime>
+  <anime anidbid="14445" tvdbid="367513" defaulttvdbseason="1" imdbid="tt10707854">
+    <name>Rifle Is Beautiful</name>
   </anime>
   <anime anidbid="14447" tvdbid="354675" defaulttvdbseason="1">
     <name>Egao no Daika</name>
@@ -32442,6 +32481,12 @@
   <anime anidbid="14480" tvdbid="313185" defaulttvdbseason="0" episodeoffset="1">
     <name>Final Fantasy XV: Episode Ardyn - Prologue</name>
   </anime>
+  <anime anidbid="14484" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Wagaya no Liliana-san The Animation</name>
+  </anime>
+  <anime anidbid="14486" tvdbid="369801" defaulttvdbseason="1" tmdbid="93819">
+    <name>Actors: Songs Connection</name>
+  </anime>
   <anime anidbid="14487" tvdbid="357448" defaulttvdbseason="0" episodeoffset="1" imdbid="tt10037700">
     <name>Eiga Precure Miracle Universe</name>
   </anime>
@@ -32462,6 +32507,9 @@
   </anime>
   <anime anidbid="14494" tvdbid="294002" defaulttvdbseason="0" episodeoffset="39">
     <name>Ple Ple Pleiades: Clementine Toubou Hen</name>
+  </anime>
+  <anime anidbid="14495" tvdbid="369139" defaulttvdbseason="1" imdbid="tt11100658">
+    <name>Gundam Build Divers Re:Rise</name>
   </anime>
   <anime anidbid="14496" tvdbid="319976" defaulttvdbseason="1">
     <name>Kidou Senshi Gundam: The Origin - Zen'ya Akai Suisei</name>
@@ -32505,14 +32553,23 @@
   <anime anidbid="14526" tvdbid="352408" defaulttvdbseason="0" episodeoffset="1">
     <name>Tensei Shitara Slime Datta Ken (2019)</name>
   </anime>
+  <anime anidbid="14527" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Tsuma ga Kirei ni Natta Wake</name>
+  </anime>
   <anime anidbid="14528" tvdbid="356486" defaulttvdbseason="1">
     <name>Papa Datte, Shitai</name>
   </anime>
   <anime anidbid="14530" tvdbid="359836" defaulttvdbseason="1">
     <name>Nobunaga-sensei no Osanazuma</name>
   </anime>
+  <anime anidbid="14532" tvdbid="movie" defaulttvdbseason="1" imdbid="tt9418812">
+    <name>Hello World</name>
+  </anime>
   <anime anidbid="14534" tvdbid="movie" defaulttvdbseason="1" imdbid="tt9426210">
     <name>Tenki no Ko</name>
+  </anime>
+  <anime anidbid="14536" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Yue ni Hitozuma wa Netorareta.</name>
   </anime>
   <anime anidbid="14543" tvdbid="358425" defaulttvdbseason="1">
     <name>Idolish Seven: Vibrato</name>
@@ -32601,6 +32658,9 @@
   <anime anidbid="14603" tvdbid="360502" defaulttvdbseason="1" imdbid="tt10362632">
     <name>Dumbbell Nan Kilo Moteru?</name>
   </anime>
+  <anime anidbid="14618" tvdbid="368905" defaulttvdbseason="1" imdbid="tt9635464">
+    <name>Hataage! Kemono Michi</name>
+  </anime>
   <anime anidbid="14623" tvdbid="347215" defaulttvdbseason="2">
     <name>Jashin-chan Dropkick 2</name>
   </anime>
@@ -32621,6 +32681,12 @@
   </anime>
   <anime anidbid="14639" tvdbid="362432" defaulttvdbseason="1">
     <name>Ling Jian Zun</name>
+  </anime>
+  <anime anidbid="14648" tvdbid="370951" defaulttvdbseason="1" imdbid="tt9845246">
+    <name>Super Shiro</name>
+  </anime>
+  <anime anidbid="14658" tvdbid="370891" defaulttvdbseason="1" tmdbid="94500">
+    <name>Shin Chuuka Ichiban!</name>
   </anime>
   <anime anidbid="14659" tvdbid="361013" defaulttvdbseason="1">
     <name>Beastars</name>
@@ -32645,6 +32711,9 @@
   </anime>
   <anime anidbid="14679" tvdbid="movie" defaulttvdbseason="1" tmdbid="594188" imdbid="tt9760504">
     <name>Ni no Kuni</name>
+  </anime>
+  <anime anidbid="14683" tvdbid="movie" defaulttvdbseason="1" tmdbid="636959">
+    <name>Eiga Sumikko Gurashi: Tobidasu Ehon to Himitsu no Ko</name>
   </anime>
   <anime anidbid="14685" tvdbid="movie" defaulttvdbseason="1" tmdbid="592867" imdbid="tt10127562">
     <name>Dragon Quest: Your Story</name>
@@ -32673,6 +32742,12 @@
   <anime anidbid="14701" tvdbid="342131" defaulttvdbseason="2">
     <name>Radiant (2019)</name>
   </anime>
+  <anime anidbid="14706" tvdbid="358331" defaulttvdbseason="0" episodeoffset="1">
+    <name>Mayonaka no Occult Koumuin: Fukurokouji to Anoko to Ore to</name>
+  </anime>
+  <anime anidbid="14708" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Master Piece The Animation</name>
+  </anime>
   <anime anidbid="14710" tvdbid="362052" defaulttvdbseason="1" imdbid="tt10427920">
     <name>Sounan Desuka?</name>
   </anime>
@@ -32694,6 +32769,9 @@
   <anime anidbid="14736" tvdbid="ova" defaulttvdbseason="1" tmdbid="587873">
     <name>Totsukuni no Shoujo</name>
   </anime>
+  <anime anidbid="14744" tvdbid="370895" defaulttvdbseason="1" imdbid="tt10814346">
+    <name>Phantasy Star Online 2: Episode Oracle</name>
+  </anime>
   <anime anidbid="14749" tvdbid="hentai" defaulttvdbseason="1">
     <name>Sakuramiya Shimai no Netorare Kiroku</name>
   </anime>
@@ -32712,14 +32790,29 @@
   <anime anidbid="14759" tvdbid="367067" defaulttvdbseason="1">
     <name>No Guns Life</name>
   </anime>
+  <anime anidbid="14763" tvdbid="movie" defaulttvdbseason="1" tmdbid="630027">
+    <name>Fragtime</name>
+  </anime>
   <anime anidbid="14773" tvdbid="web" defaulttvdbseason="1">
     <name>Ero Lover</name>
   </anime>
   <anime anidbid="14776" tvdbid="305074" defaulttvdbseason="0" episodeoffset="6">
     <name>Boku no Hero Academia the Movie: Heroes:Rising</name>
   </anime>
+  <anime anidbid="14777" tvdbid="368757" defaulttvdbseason="1" imdbid="tt10054654">
+    <name>Keishichou Tokumu Bu Tokushu Kyouakuhan Taisaku Shitsu Dai Nana Ka: Tokunana</name>
+  </anime>
+  <anime anidbid="14779" tvdbid="movie" defaulttvdbseason="1" imdbid="tt10981202">
+    <name>Sora no Aosa o Shiru Hito yo</name>
+  </anime>
   <anime anidbid="14780" tvdbid="346673" defaulttvdbseason="2">
     <name>High Score Girl II</name>
+  </anime>
+  <anime anidbid="14786" tvdbid="movie" defaulttvdbseason="1">
+    <name>Thunderbolt Fantasy: Seiyuu Genka</name>
+  </anime>
+  <anime anidbid="14787" tvdbid="movie" imdbid="tt10622220">
+    <name>Human Lost</name>
   </anime>
   <anime anidbid="14791" tvdbid="346931" defaulttvdbseason="2">
     <name>Hataraku Saibou 2</name>
@@ -32736,8 +32829,14 @@
   <anime anidbid="14801" tvdbid="348002" defaulttvdbseason="2">
     <name>Yakusoku no Neverland (2020)</name>
   </anime>
+  <anime anidbid="14802" tvdbid="320002" defaulttvdbseason="0" episodeoffset="11" imdbid="tt11056458">
+    <name>Bang Dream! Film Live</name>
+  </anime>
   <anime anidbid="14805" tvdbid="366358" defaulttvdbseason="1" tmdbid="90847">
     <name>Hakata Mentai! Pirikarako-chan</name>
+  </anime>
+  <anime anidbid="14806" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Kaijuu Step Wandabada</name>
   </anime>
   <anime anidbid="14808" tvdbid="hentai" defaulttvdbseason="1">
     <name>Tenioha! 2: Nee, Motto Ecchi na Koto Ippai Shiyo? The Animation</name>
@@ -32763,6 +32862,9 @@
   <anime anidbid="14857" tvdbid="319997" defaulttvdbseason="0" episodeoffset="4">
     <name>Chokotto Anime Kemono Friends 3</name>
   </anime>
+  <anime anidbid="14858" tvdbid="369749" defaulttvdbseason="1" tmdbid="93828">
+    <name>Tenka Hyakken: Meiji-kan e Youkoso!</name>
+  </anime>
   <anime anidbid="14875" tvdbid="311607" defaulttvdbseason="2">
     <name>Flowering Heart 2</name>
   </anime>
@@ -32777,6 +32879,9 @@
   </anime>
   <anime anidbid="14906" tvdbid="hentai" defaulttvdbseason="1">
     <name>Ochi Mono RPG Seikishi Luvilias</name>
+  </anime>
+  <anime anidbid="14908" tvdbid="366706" defaulttvdbseason="1" imdbid="tt10974256">
+    <name>Val x Love</name>
   </anime>
   <anime anidbid="14909" tvdbid="hentai" defaulttvdbseason="1">
     <name>Joshi Luck!</name>
@@ -32808,17 +32913,32 @@
   <anime anidbid="14924" tvdbid="hentai" defaulttvdbseason="1">
     <name>Yubisaki kara Honki no Netsujou: Osananajimi wa Shouboushi</name>
   </anime>
+  <anime anidbid="14941" tvdbid="307375" defaulttvdbseason="0" episodeoffset="7">
+    <name>Mob Psycho 100: Daiikkai Rei toka Soudansho Ian Ryokou - Kokoro Mitasu Iyashi no Tabi</name>
+  </anime>
+  <anime anidbid="14946" tvdbid="movie" defaulttvdbseason="1" imdbid="tt10476540">
+    <name>Santa Company: Christmas no Himitsu</name>
+  </anime>
   <anime anidbid="14951" tvdbid="289909" defaulttvdbseason="4">
     <name>Shokugeki no Souma: Shin no Sara</name>
   </anime>
+  <anime anidbid="14956" tvdbid="327261" defaulttvdbseason="3">
+    <name>Ani ni Tsukeru Kusuri wa Nai! 3</name>
+  </anime>
   <anime anidbid="14964" tvdbid="357471" defaulttvdbseason="2">
     <name>Isekai Quartet 2</name>
+  </anime>
+  <anime anidbid="14965" tvdbid="361217" defaulttvdbseason="0" tmdbid="632088">
+    <name>Strike Witches: Gekijouban 501 Butai Hasshin Shimasu!</name>
   </anime>
   <anime anidbid="14968" tvdbid="359095" defaulttvdbseason="2">
     <name>Bokutachi wa Benkyou ga Dekinai!</name>
   </anime>
   <anime anidbid="14970" tvdbid="movie" defaulttvdbseason="1">
     <name>Cencoroll 3</name>
+  </anime>
+  <anime anidbid="14971" tvdbid="250022" defaulttvdbseason="0" episodeoffset="4">
+    <name>Mini Yuri</name>
   </anime>
   <anime anidbid="14972" tvdbid="366357" defaulttvdbseason="1">
     <name>Waresho! Warera! Shoudoubutsu Aigo Iinkai</name>
@@ -32847,13 +32967,91 @@
   <anime anidbid="14988" tvdbid="357488" defaulttvdbseason="2">
     <name>Fruits Basket 2nd Season</name>
   </anime>
+  <anime anidbid="14989" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Kutsujoku</name>
+  </anime>
   <anime anidbid="14995" tvdbid="338455" defaulttvdbseason="3">
     <name>Golden Kamuy 3</name>
+  </anime>
+  <anime anidbid="15003" tvdbid="movie" defaulttvdbseason="1" imdbid="tt10621032">
+    <name>Lupin Sansei: The First</name>
+  </anime>
+  <anime anidbid="15010" tvdbid="web" defaulttvdbseason="1" imdbid="tt10682000">
+    <name>Sound &amp; Fury</name>
+  </anime>
+  <anime anidbid="15022" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Naedoko Demon's Ground</name>
+  </anime>
+  <anime anidbid="15023" tvdbid="369145" defaulttvdbseason="1" tmdbid="91587">
+    <name>Null Peta</name>
+  </anime>
+  <anime anidbid="15024" tvdbid="369146" defaulttvdbseason="1" imdbid="tt10978032">
+    <name>Kandagawa Jet Girls</name>
+  </anime>
+  <anime anidbid="15025" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Shigokare: Ecchi na Joshi Daisei to Doki x2 Love Lesson!! The Animation</name>
   </anime>
   <anime anidbid="15026" tvdbid="347578" defaulttvdbseason="2">
     <name>Zoids Wild Zero</name>
   </anime>
   <anime anidbid="15028" tvdbid="351953" defaulttvdbseason="2">
     <name>Zombie Land Saga Revenge</name>
+  </anime>
+  <anime anidbid="15033" tvdbid="370373" defaulttvdbseason="1" tmdbid="94214">
+    <name>Urashimasakatasen no Nichijou</name>
+  </anime>
+  <anime anidbid="15036" tvdbid="313676" defaulttvdbseason="2" tmdbid="94190">
+    <name>Bananya: Fushigi na Nakama-tachi</name>
+  </anime>
+  <anime anidbid="15044" tvdbid="hentai" defaulttvdbseason="1">
+    <name>XL Joushi.</name>
+  </anime>
+  <anime anidbid="15047" tvdbid="370508" defaulttvdbseason="1" tmdbid="94313">
+    <name>Aikatsu on Parade!</name>
+  </anime>
+  <anime anidbid="15052" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Subarashiki Kokka no Kizukikata</name>
+  </anime>
+  <anime anidbid="15061" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Aibeya The Animation</name>
+  </anime>
+  <anime anidbid="15062" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Love x Holic: Miwaku no Otome to Hakudaku Kankei The Animation</name>
+  </anime>
+  <anime anidbid="15067" tvdbid="76703" defaulttvdbseason="19">
+    <name>Pocket Monsters (2019)</name>
+  </anime>
+  <anime anidbid="15075" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Go! Go! Atom</name>
+  </anime>
+  <anime anidbid="15076" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Egg Car</name>
+  </anime>
+  <anime anidbid="15093" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Valkyrie Hazard</name>
+  </anime>
+  <anime anidbid="15094" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Hitozuma, Mitsu to Niku</name>
+  </anime>
+  <anime anidbid="15101" tvdbid="370501" defaulttvdbseason="1" tmdbid="94299">
+    <name>Taeko no Nichijou</name>
+  </anime>
+  <anime anidbid="15109" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Mono no Kamisama Cocotama</name>
+  </anime>
+  <anime anidbid="15112" tvdbid="unknown">
+    <name>Sylvanian Families: Mini Story - Clover</name>
+  </anime>
+  <anime anidbid="15114" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Nozoki Kanojo</name>
+  </anime>
+  <anime anidbid="15115" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Boku to Joi no Shinsatsu Nisshi The Animation</name>
+  </anime>
+  <anime anidbid="15116" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Shen Bing Xiao Jiang</name>
+  </anime>
+  <anime anidbid="15117" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Miki no Mikoto</name>
   </anime>
 </anime-list>

--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -30492,7 +30492,7 @@
   <anime anidbid="12512" tvdbid="hentai" defaulttvdbseason="1">
     <name>Saimin Class: Joshi Zen'in, Shiranai Uchi ni Ninshin Shitemashita</name>
   </anime>
-  <anime anidbid="12519" tvdbid="278626" defaulttvdbseason="0" episodeoffset="2" imdbid="tt6213810">
+  <anime anidbid="12519" tvdbid="353666" defaulttvdbseason="0" imdbid="tt6213810">
     <name>Fate/Grand Order: First Order</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -31714,10 +31714,10 @@
   <anime anidbid="13641" tvdbid="movie" defaulttvdbseason="1" tmdbid="466980" imdbid="tt7146054">
     <name>Dahufa</name>
   </anime>
-  <anime anidbid="13643" tvdbid="278626" defaulttvdbseason="0" episodeoffset="4">
+  <anime anidbid="13643" tvdbid="353666" defaulttvdbseason="0" episodeoffset="1" tmdbid="495907">
     <name>Fate/Grand Order: Moonlight/Lostroom</name>
   </anime>
-  <anime anidbid="13644" tvdbid="278626" defaulttvdbseason="0" episodeoffset="5">
+  <anime anidbid="13644" tvdbid="353666" defaulttvdbseason="0" episodeoffset="2" tmdbid="496432">
     <name>Fate/Grand Order x Himuro no Tenchi: 7-nin no Saikyou Ijin Hen</name>
   </anime>
   <anime anidbid="13649" tvdbid="76703" defaulttvdbseason="0" imdbid="tt8108230">
@@ -32309,6 +32309,12 @@
   </anime>
   <anime anidbid="14238" tvdbid="353666" defaulttvdbseason="1" imdbid="tt9525238">
     <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
+	<mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-4;</mapping>
+    </mapping-list>
+  </anime>
+  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202, 637462">
+    <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
   </anime>
   <anime anidbid="14241" tvdbid="353244" defaulttvdbseason="1">
     <name>Okoshiyasu, Chitose-chan</name>
@@ -32619,11 +32625,8 @@
   <anime anidbid="14574" tvdbid="361491" defaulttvdbseason="1" tmdbid="88050" imdbid="tt10347516">
     <name>Cop Craft</name>
   </anime>
-  <anime anidbid="14579" tvdbid="278626" defaulttvdbseason="0">
+  <anime anidbid="14579" tvdbid="353666" defaulttvdbseason="0" episodeoffset="3">
     <name>Manga de Wakaru! Fate/Grand Order</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-9;2-9;3-9;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="14580" tvdbid="357492" defaulttvdbseason="1" tmdbid="85368" imdbid="tt9573854">
     <name>Lord El-Melloi II-sei no Jikenbo: Rail Zeppelin Grace Note</name>

--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -32627,6 +32627,9 @@
   </anime>
   <anime anidbid="14579" tvdbid="353666" defaulttvdbseason="0" episodeoffset="3">
     <name>Manga de Wakaru! Fate/Grand Order</name>
+	<mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-4;2-4;3-4;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="14580" tvdbid="357492" defaulttvdbseason="1" tmdbid="85368" imdbid="tt9573854">
     <name>Lord El-Melloi II-sei no Jikenbo: Rail Zeppelin Grace Note</name>

--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -32313,7 +32313,7 @@
       <mapping anidbseason="0" tvdbseason="0">;1-4;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202, 637462">
+  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202,637462">
     <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
   </anime>
   <anime anidbid="14241" tvdbid="353244" defaulttvdbseason="1">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -39111,7 +39111,7 @@
       <mapping anidbseason="0" tvdbseason="0">;1-4;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202, 637462" imdbid="">
+  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202,637462" imdbid="">
     <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
   </anime>
   <anime anidbid="14240" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -34206,7 +34206,7 @@
   <anime anidbid="12518" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Shimajirou to Niji no Oasis</name>
   </anime>
-  <anime anidbid="12519" tvdbid="278626" defaulttvdbseason="0" episodeoffset="2" tmdbid="" imdbid="tt6213810">
+  <anime anidbid="12519" tvdbid="353666" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt6213810">
     <name>Fate/Grand Order: First Order</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -37420,10 +37420,10 @@
   <anime anidbid="13642" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Shi Wan Ge Leng Xiaohua 2</name>
   </anime>
-  <anime anidbid="13643" tvdbid="278626" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="">
+  <anime anidbid="13643" tvdbid="353666" defaulttvdbseason="0" episodeoffset="1" tmdbid="495907" imdbid="">
     <name>Fate/Grand Order: Moonlight/Lostroom</name>
   </anime>
-  <anime anidbid="13644" tvdbid="278626" defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="">
+  <anime anidbid="13644" tvdbid="353666" defaulttvdbseason="0" episodeoffset="2" tmdbid="496432" imdbid="">
     <name>Fate/Grand Order x Himuro no Tenchi: 7-nin no Saikyou Ijin Hen</name>
   </anime>
   <anime anidbid="13645" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39107,8 +39107,11 @@
   </anime>
   <anime anidbid="14238" tvdbid="353666" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt9525238">
     <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
+	<mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-4;</mapping>
+    </mapping-list>
   </anime>
-  <anime anidbid="14239" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202, 637462" imdbid="">
     <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
   </anime>
   <anime anidbid="14240" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40080,11 +40083,8 @@
   <anime anidbid="14578" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Affordance</name>
   </anime>
-  <anime anidbid="14579" tvdbid="278626" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14579" tvdbid="353666" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="">
     <name>Manga de Wakaru! Fate/Grand Order</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-9;2-9;3-9;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="14580" tvdbid="357492" defaulttvdbseason="1" episodeoffset="" tmdbid="85368" imdbid="tt9573854">
     <name>Lord El-Melloi II-sei no Jikenbo: Rail Zeppelin Grace Note</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -35898,7 +35898,7 @@
   <anime anidbid="13106" tvdbid="293121" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Himouto! Umaru-chan R</name>
   </anime>
-  <anime anidbid="13108" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13108" tvdbid="283929" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="">
     <name>Gekijouban Gundam G no Reconguista</name>
   </anime>
   <anime anidbid="13110" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -36841,7 +36841,7 @@
   <anime anidbid="13440" tvdbid="353219" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Gaikotsu Shoten'in Honda-san</name>
   </anime>
-  <anime anidbid="13441" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13441" tvdbid="353455" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt11070000">
     <name>Z/X: Code Reunion</name>
   </anime>
   <anime anidbid="13442" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -38000,7 +38000,7 @@
   <anime anidbid="13843" tvdbid="85192" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Souten no Ken: Regenesis (2018)</name>
   </anime>
-  <anime anidbid="13844" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13844" tvdbid="368861" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10882992">
     <name>Watashi, Nouryoku wa Heikinchi dette Itta yo ne!</name>
   </anime>
   <anime anidbid="13845" tvdbid="347578" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -38015,7 +38015,7 @@
   <anime anidbid="13848" tvdbid="365720" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ahiru no Sora</name>
   </anime>
-  <anime anidbid="13849" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13849" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Dokidoki Little Ooyasan</name>
   </anime>
   <anime anidbid="13850" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -38196,7 +38196,7 @@
   <anime anidbid="13914" tvdbid="325374" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Duel Masters!</name>
   </anime>
-  <anime anidbid="13915" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13915" tvdbid="ova" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bean Bandit</name>
   </anime>
   <anime anidbid="13916" tvdbid="347467" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -38220,7 +38220,7 @@
   <anime anidbid="13923" tvdbid="345100" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Double Decker! Doug &amp; Kirill</name>
   </anime>
-  <anime anidbid="13924" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13924" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt8816016">
     <name>Black Fox</name>
   </anime>
   <anime anidbid="13925" tvdbid="351751" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -38538,7 +38538,7 @@
   <anime anidbid="14040" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wara! Pyeonuijeom</name>
   </anime>
-  <anime anidbid="14041" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14041" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="6356813" imdbid="">
     <name>Kimi dake ni Motetainda.</name>
   </anime>
   <anime anidbid="14042" tvdbid="142601" defaulttvdbseason="0" episodeoffset="9" tmdbid="" imdbid="">
@@ -38556,7 +38556,7 @@
   <anime anidbid="14046" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Morimori Shima no Mogu to Perol</name>
   </anime>
-  <anime anidbid="14047" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14047" tvdbid="250022" defaulttvdbseason="0" episodeoffset="9" tmdbid="" imdbid="">
     <name>Yuru Yuri Ten</name>
   </anime>
   <anime anidbid="14048" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39105,7 +39105,7 @@
   <anime anidbid="14237" tvdbid="353579" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ken En Ken: Aoki Kagayaki</name>
   </anime>
-  <anime anidbid="14238" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14238" tvdbid="353666" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt9525238">
     <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
   </anime>
   <anime anidbid="14239" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39570,7 +39570,7 @@
   <anime anidbid="14397" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Seishun Buta Yarou wa Yumemiru Shoujo no Yume o Minai</name>
   </anime>
-  <anime anidbid="14398" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14398" tvdbid="361439" defaulttvdbseason="1" episodeoffset="" tmdbid="93818" imdbid="">
     <name>Stand My Heroes: Piece of Truth</name>
   </anime>
   <anime anidbid="14399" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -39606,7 +39606,7 @@
   <anime anidbid="14409" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lost Song (Shinsaku)</name>
   </anime>
-  <anime anidbid="14410" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14410" tvdbid="368366" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt11033998">
     <name>Chuubyou Gekihatsu Boy</name>
   </anime>
   <anime anidbid="14411" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39693,7 +39693,7 @@
   <anime anidbid="14441" tvdbid="114921" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Toaru Kagaku no Railgun T</name>
   </anime>
-  <anime anidbid="14442" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14442" tvdbid="368862" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10883006">
     <name>Ore o Suki na no wa Omae Dake ka yo</name>
   </anime>
   <anime anidbid="14443" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39702,7 +39702,7 @@
   <anime anidbid="14444" tvdbid="267440" defaulttvdbseason="3" episodeoffset="12" tmdbid="" imdbid="">
     <name>Shingeki no Kyojin Season 3 (2019)</name>
   </anime>
-  <anime anidbid="14445" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14445" tvdbid="367513" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10707854">
     <name>Rifle Is Beautiful</name>
   </anime>
   <anime anidbid="14446" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39813,13 +39813,13 @@
   <anime anidbid="14483" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Dorohedoro</name>
   </anime>
-  <anime anidbid="14484" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14484" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Wagaya no Liliana-san The Animation</name>
   </anime>
   <anime anidbid="14485" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tsukiuta. The Animation 2</name>
   </anime>
-  <anime anidbid="14486" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14486" tvdbid="369801" defaulttvdbseason="1" episodeoffset="" tmdbid="93819" imdbid="">
     <name>Actors: Songs Connection</name>
   </anime>
   <anime anidbid="14487" tvdbid="357448" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="tt10037700">
@@ -39846,7 +39846,7 @@
   <anime anidbid="14494" tvdbid="294002" defaulttvdbseason="0" episodeoffset="39" tmdbid="" imdbid="">
     <name>Ple Ple Pleiades: Clementine Toubou Hen</name>
   </anime>
-  <anime anidbid="14495" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14495" tvdbid="369139" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt11100658">
     <name>Gundam Build Divers Re:Rise</name>
   </anime>
   <anime anidbid="14496" tvdbid="319976" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -39936,7 +39936,7 @@
   <anime anidbid="14526" tvdbid="352408" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="">
     <name>Tensei Shitara Slime Datta Ken (2019)</name>
   </anime>
-  <anime anidbid="14527" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14527" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Tsuma ga Kirei ni Natta Wake</name>
   </anime>
   <anime anidbid="14528" tvdbid="356486" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -39951,7 +39951,7 @@
   <anime anidbid="14531" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Aggressive Retsuko: We Wish You a Metal Christmas</name>
   </anime>
-  <anime anidbid="14532" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14532" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt9418812">
     <name>Hello World</name>
   </anime>
   <anime anidbid="14533" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -39963,7 +39963,7 @@
   <anime anidbid="14535" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hachi-nan tte, Sore wa Nai deshou!</name>
   </anime>
-  <anime anidbid="14536" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14536" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Yue ni Hitozuma wa Netorareta.</name>
   </anime>
   <anime anidbid="14537" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40194,7 +40194,7 @@
   <anime anidbid="14617" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Nogsaegjeoncha Hamos</name>
   </anime>
-  <anime anidbid="14618" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14618" tvdbid="368905" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt9635464">
     <name>Hataage! Kemono Michi</name>
   </anime>
   <anime anidbid="14619" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40278,7 +40278,7 @@
   <anime anidbid="14647" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hua Jianghu: Buliang Ren Di San Ji</name>
   </anime>
-  <anime anidbid="14648" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14648" tvdbid="370951" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt9845246">
     <name>Super Shiro</name>
   </anime>
   <anime anidbid="14649" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40308,7 +40308,7 @@
   <anime anidbid="14657" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Qing Chi Hong Xiaodou Ba! Di Er Ji</name>
   </anime>
-  <anime anidbid="14658" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14658" tvdbid="370891" defaulttvdbseason="1" episodeoffset="" tmdbid="94500" imdbid="">
     <name>Shin Chuuka Ichiban!</name>
   </anime>
   <anime anidbid="14659" tvdbid="361013" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -40383,7 +40383,7 @@
   <anime anidbid="14682" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Pandora to Akubi</name>
   </anime>
-  <anime anidbid="14683" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14683" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="636959" imdbid="">
     <name>Eiga Sumikko Gurashi: Tobidasu Ehon to Himitsu no Ko</name>
   </anime>
   <anime anidbid="14684" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40443,13 +40443,13 @@
   <anime anidbid="14705" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Rainbow Ruby</name>
   </anime>
-  <anime anidbid="14706" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14706" tvdbid="358331" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="">
     <name>Mayonaka no Occult Koumuin: Fukurokouji to Anoko to Ore to</name>
   </anime>
   <anime anidbid="14707" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Koisuru Asteroid</name>
   </anime>
-  <anime anidbid="14708" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14708" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Master Piece The Animation</name>
   </anime>
   <anime anidbid="14709" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40554,7 +40554,7 @@
   <anime anidbid="14743" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>JA Kumamoto Keizairen</name>
   </anime>
-  <anime anidbid="14744" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14744" tvdbid="370895" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10814346">
     <name>Phantasy Star Online 2: Episode Oracle</name>
   </anime>
   <anime anidbid="14745" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40611,7 +40611,7 @@
   <anime anidbid="14762" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ahare! Meisaku-kun (2019)</name>
   </anime>
-  <anime anidbid="14763" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14763" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="630027" imdbid="">
     <name>Fragtime</name>
   </anime>
   <anime anidbid="14764" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40650,13 +40650,13 @@
   <anime anidbid="14776" tvdbid="305074" defaulttvdbseason="0" episodeoffset="6" tmdbid="" imdbid="">
     <name>Boku no Hero Academia the Movie: Heroes:Rising</name>
   </anime>
-  <anime anidbid="14777" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14777" tvdbid="368757" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10054654">
     <name>Keishichou Tokumu Bu Tokushu Kyouakuhan Taisaku Shitsu Dai Nana Ka: Tokunana</name>
   </anime>
   <anime anidbid="14778" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>An tu! An tu!</name>
   </anime>
-  <anime anidbid="14779" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14779" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10981202">
     <name>Sora no Aosa o Shiru Hito yo</name>
   </anime>
   <anime anidbid="14780" tvdbid="346673" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
@@ -40677,10 +40677,10 @@
   <anime anidbid="14785" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Somali to Mori no Kamisama</name>
   </anime>
-  <anime anidbid="14786" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14786" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Thunderbolt Fantasy: Seiyuu Genka</name>
   </anime>
-  <anime anidbid="14787" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14787" tvdbid="movie" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="tt10622220">
     <name>Human Lost</name>
   </anime>
   <anime anidbid="14788" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40725,7 +40725,7 @@
   <anime anidbid="14801" tvdbid="348002" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Yakusoku no Neverland (2020)</name>
   </anime>
-  <anime anidbid="14802" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14802" tvdbid="320002" defaulttvdbseason="0" episodeoffset="11" tmdbid="" imdbid="tt11056458">
     <name>Bang Dream! Film Live</name>
   </anime>
   <anime anidbid="14803" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40737,7 +40737,7 @@
   <anime anidbid="14805" tvdbid="366358" defaulttvdbseason="1" episodeoffset="" tmdbid="90847" imdbid="">
     <name>Hakata Mentai! Pirikarako-chan</name>
   </anime>
-  <anime anidbid="14806" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14806" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kaijuu Step Wandabada</name>
   </anime>
   <anime anidbid="14807" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40881,7 +40881,7 @@
   <anime anidbid="14857" tvdbid="319997" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="">
     <name>Chokotto Anime Kemono Friends 3</name>
   </anime>
-  <anime anidbid="14858" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14858" tvdbid="369749" defaulttvdbseason="1" episodeoffset="" tmdbid="93828" imdbid="">
     <name>Tenka Hyakken: Meiji-kan e Youkoso!</name>
   </anime>
   <anime anidbid="14860" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41022,7 +41022,7 @@
   <anime anidbid="14907" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eizouken ni wa Te o Dasu na!</name>
   </anime>
-  <anime anidbid="14908" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14908" tvdbid="366706" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10974256">
     <name>Val x Love</name>
   </anime>
   <anime anidbid="14909" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -41115,7 +41115,7 @@
   <anime anidbid="14940" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Sabiiro no Armor</name>
   </anime>
-  <anime anidbid="14941" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14941" tvdbid="307375" defaulttvdbseason="0" episodeoffset="7" tmdbid="" imdbid="">
     <name>Mob Psycho 100: Daiikkai Rei toka Soudansho Ian Ryokou - Kokoro Mitasu Iyashi no Tabi</name>
   </anime>
   <anime anidbid="14942" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41127,7 +41127,7 @@
   <anime anidbid="14944" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wan Jie Xian Zong Di Er Ji</name>
   </anime>
-  <anime anidbid="14946" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14946" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10476540">
     <name>Santa Company: Christmas no Himitsu</name>
   </anime>
   <anime anidbid="14948" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41148,7 +41148,7 @@
   <anime anidbid="14954" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Chui Zhi Shi Jie</name>
   </anime>
-  <anime anidbid="14956" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14956" tvdbid="327261" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Ani ni Tsukeru Kusuri wa Nai! 3</name>
   </anime>
   <anime anidbid="14957" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41175,7 +41175,7 @@
   <anime anidbid="14964" tvdbid="357471" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Isekai Quartet 2</name>
   </anime>
-  <anime anidbid="14965" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14965" tvdbid="361217" defaulttvdbseason="0" episodeoffset="" tmdbid="632088" imdbid="">
     <name>Strike Witches: Gekijouban 501 Butai Hasshin Shimasu!</name>
   </anime>
   <anime anidbid="14966" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41190,7 +41190,7 @@
   <anime anidbid="14970" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Cencoroll 3</name>
   </anime>
-  <anime anidbid="14971" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14971" tvdbid="250022" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="">
     <name>Mini Yuri</name>
   </anime>
   <anime anidbid="14972" tvdbid="366357" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -41244,7 +41244,7 @@
   <anime anidbid="14988" tvdbid="357488" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Fruits Basket 2nd Season</name>
   </anime>
-  <anime anidbid="14989" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14989" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kutsujoku</name>
   </anime>
   <anime anidbid="14990" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41283,7 +41283,7 @@
   <anime anidbid="15002" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Koi to Producer: Evol x Love</name>
   </anime>
-  <anime anidbid="15003" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15003" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10621032">
     <name>Lupin Sansei: The First</name>
   </anime>
   <anime anidbid="15004" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41304,7 +41304,7 @@
   <anime anidbid="15009" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ninja Box</name>
   </anime>
-  <anime anidbid="15010" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15010" tvdbid="web" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10682000">
     <name>Sound &amp; Fury</name>
   </anime>
   <anime anidbid="15011" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41340,16 +41340,16 @@
   <anime anidbid="15021" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hero Mask (2019)</name>
   </anime>
-  <anime anidbid="15022" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15022" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Naedoko Demon's Ground</name>
   </anime>
-  <anime anidbid="15023" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15023" tvdbid="369145" defaulttvdbseason="1" episodeoffset="" tmdbid="91587" imdbid="">
     <name>Null Peta</name>
   </anime>
-  <anime anidbid="15024" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15024" tvdbid="369146" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10978032">
     <name>Kandagawa Jet Girls</name>
   </anime>
-  <anime anidbid="15025" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15025" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Shigokare: Ecchi na Joshi Daisei to Doki x2 Love Lesson!! The Animation</name>
   </anime>
   <anime anidbid="15026" tvdbid="347578" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
@@ -41373,7 +41373,7 @@
   <anime anidbid="15032" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>BeyWarriors: Cyborg</name>
   </anime>
-  <anime anidbid="15033" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15033" tvdbid="370373" defaulttvdbseason="1" episodeoffset="" tmdbid="94214" imdbid="">
     <name>Urashimasakatasen no Nichijou</name>
   </anime>
   <anime anidbid="15034" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41382,7 +41382,7 @@
   <anime anidbid="15035" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Quanzhi Gaoshou zhi Dianfeng Rongyao</name>
   </anime>
-  <anime anidbid="15036" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15036" tvdbid="313676" defaulttvdbseason="2" episodeoffset="" tmdbid="94190" imdbid="">
     <name>Bananya: Fushigi na Nakama-tachi</name>
   </anime>
   <anime anidbid="15037" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41406,7 +41406,7 @@
   <anime anidbid="15043" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Jumbagi: Hanbandoui Gongryong 3D</name>
   </anime>
-  <anime anidbid="15044" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15044" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>XL Joushi.</name>
   </anime>
   <anime anidbid="15045" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41415,7 +41415,7 @@
   <anime anidbid="15046" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wave!!</name>
   </anime>
-  <anime anidbid="15047" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15047" tvdbid="370508" defaulttvdbseason="1" episodeoffset="" tmdbid="94313" imdbid="">
     <name>Aikatsu on Parade!</name>
   </anime>
   <anime anidbid="15048" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41430,7 +41430,7 @@
   <anime anidbid="15051" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zetsubou no Kaibutsu</name>
   </anime>
-  <anime anidbid="15052" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15052" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Subarashiki Kokka no Kizukikata</name>
   </anime>
   <anime anidbid="15053" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41457,10 +41457,10 @@
   <anime anidbid="15060" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Crayon Shin-chan: Gekitotsu! Rakugaki Kingdom to Hobo Yonin no Yuusha</name>
   </anime>
-  <anime anidbid="15061" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15061" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Aibeya The Animation</name>
   </anime>
-  <anime anidbid="15062" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15062" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Love x Holic: Miwaku no Otome to Hakudaku Kankei The Animation</name>
   </anime>
   <anime anidbid="15063" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41475,7 +41475,7 @@
   <anime anidbid="15066" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Girl X</name>
   </anime>
-  <anime anidbid="15067" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15067" tvdbid="76703" defaulttvdbseason="19" episodeoffset="" tmdbid="" imdbid="">
     <name>Pocket Monsters (2019)</name>
   </anime>
   <anime anidbid="15068" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41499,10 +41499,10 @@
   <anime anidbid="15074" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kuuchuu Gunkan Atlantis</name>
   </anime>
-  <anime anidbid="15075" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15075" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Go! Go! Atom</name>
   </anime>
-  <anime anidbid="15076" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15076" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Egg Car</name>
   </anime>
   <anime anidbid="15077" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41553,10 +41553,10 @@
   <anime anidbid="15092" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zenonzard: The Animation</name>
   </anime>
-  <anime anidbid="15093" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15093" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Valkyrie Hazard</name>
   </anime>
-  <anime anidbid="15094" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15094" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Hitozuma, Mitsu to Niku</name>
   </anime>
   <anime anidbid="15095" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41574,7 +41574,7 @@
   <anime anidbid="15100" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Date a Bullet</name>
   </anime>
-  <anime anidbid="15101" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15101" tvdbid="370501" defaulttvdbseason="1" episodeoffset="" tmdbid="94299" imdbid="">
     <name>Taeko no Nichijou</name>
   </anime>
   <anime anidbid="15102" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41595,7 +41595,7 @@
   <anime anidbid="15108" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Obsolete</name>
   </anime>
-  <anime anidbid="15109" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15109" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mono no Kamisama Cocotama</name>
   </anime>
   <anime anidbid="15110" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -41604,22 +41604,22 @@
   <anime anidbid="15111" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Dungeon ni Deai o Motomeru no wa Machigatte Iru Darouka: Familia Myth III</name>
   </anime>
-  <anime anidbid="15112" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15112" tvdbid="unknown" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Sylvanian Families: Mini Story - Clover</name>
   </anime>
   <anime anidbid="15113" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gekijouban Kimetsu no Yaiba: Mugen Ressha Hen</name>
   </anime>
-  <anime anidbid="15114" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15114" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Nozoki Kanojo</name>
   </anime>
-  <anime anidbid="15115" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15115" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Boku to Joi no Shinsatsu Nisshi The Animation</name>
   </anime>
-  <anime anidbid="15116" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15116" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Shen Bing Xiao Jiang</name>
   </anime>
-  <anime anidbid="15117" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15117" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Miki no Mikoto</name>
   </anime>
 </anime-list>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -40085,6 +40085,9 @@
   </anime>
   <anime anidbid="14579" tvdbid="353666" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="">
     <name>Manga de Wakaru! Fate/Grand Order</name>
+	<mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-4;2-4;3-4;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="14580" tvdbid="357492" defaulttvdbseason="1" episodeoffset="" tmdbid="85368" imdbid="tt9573854">
     <name>Lord El-Melloi II-sei no Jikenbo: Rail Zeppelin Grace Note</name>

--- a/anime-list-todo.xml
+++ b/anime-list-todo.xml
@@ -6817,9 +6817,6 @@
   <anime anidbid="14236" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Nijuuseiki Denki Mokuroku</name>
   </anime>
-  <anime anidbid="14239" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
-  </anime>
   <anime anidbid="14240" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Digimon Adventure: Last Evolution Kizuna</name>
   </anime>
@@ -8588,4 +8585,4 @@
     <name>Gekijouban Kimetsu no Yaiba: Mugen Ressha Hen</name>
   </anime>
 </anime-list>
-<!--2856 titles remaining-->
+<!--2855 titles remaining-->

--- a/anime-list-todo.xml
+++ b/anime-list-todo.xml
@@ -4858,9 +4858,6 @@
   <anime anidbid="13105" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Otoppe</name>
   </anime>
-  <anime anidbid="13108" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Gekijouban Gundam G no Reconguista</name>
-  </anime>
   <anime anidbid="13110" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Yousei Land Mukashibanashi</name>
   </anime>
@@ -5409,9 +5406,6 @@
   </anime>
   <anime anidbid="13435" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hinamatsuri</name>
-  </anime>
-  <anime anidbid="13441" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Z/X: Code Reunion</name>
   </anime>
   <anime anidbid="13442" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Xiang Ling Ji</name>
@@ -6133,14 +6127,8 @@
   <anime anidbid="13842" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Meitantei Conan: Hoshikage no Magician</name>
   </anime>
-  <anime anidbid="13844" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Watashi, Nouryoku wa Heikinchi dette Itta yo ne!</name>
-  </anime>
   <anime anidbid="13847" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gekijouban PriPara &amp; Kiratto Pri Chan: Kirakira Memorial Live</name>
-  </anime>
-  <anime anidbid="13849" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Dokidoki Little Ooyasan</name>
   </anime>
   <anime anidbid="13850" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wangzhe Wai Chuan</name>
@@ -6262,9 +6250,6 @@
   <anime anidbid="13910" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Houkago no Yuutousei</name>
   </anime>
-  <anime anidbid="13915" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Bean Bandit</name>
-  </anime>
   <anime anidbid="13920" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Chikyuu to no Yakusoku</name>
   </anime>
@@ -6273,9 +6258,6 @@
   </anime>
   <anime anidbid="13922" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wan Gu Xian Qiong II</name>
-  </anime>
-  <anime anidbid="13924" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Black Fox</name>
   </anime>
   <anime anidbid="13926" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Hugtto! Precure x Futari wa Precure: All Stars Memories</name>
@@ -6490,9 +6472,6 @@
   <anime anidbid="14040" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wara! Pyeonuijeom</name>
   </anime>
-  <anime anidbid="14041" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Kimi dake ni Motetainda.</name>
-  </anime>
   <anime anidbid="14043" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kidou Senshi Gundam: Senkou no Hathaway</name>
   </anime>
@@ -6501,9 +6480,6 @@
   </anime>
   <anime anidbid="14046" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Morimori Shima no Mogu to Perol</name>
-  </anime>
-  <anime anidbid="14047" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Yuru Yuri Ten</name>
   </anime>
   <anime anidbid="14048" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Mahjong Hishouden: Naki no Ryuu - Hiryuu no Shou</name>
@@ -6840,9 +6816,6 @@
   </anime>
   <anime anidbid="14236" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Nijuuseiki Denki Mokuroku</name>
-  </anime>
-  <anime anidbid="14238" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
   </anime>
   <anime anidbid="14239" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
@@ -7228,9 +7201,6 @@
   <anime anidbid="14397" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Seishun Buta Yarou wa Yumemiru Shoujo no Yume o Minai</name>
   </anime>
-  <anime anidbid="14398" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Stand My Heroes: Piece of Truth</name>
-  </anime>
   <anime anidbid="14402" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tian Xing Jiu Ge</name>
   </anime>
@@ -7251,9 +7221,6 @@
   </anime>
   <anime anidbid="14409" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lost Song (Shinsaku)</name>
-  </anime>
-  <anime anidbid="14410" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Chuubyou Gekihatsu Boy</name>
   </anime>
   <anime anidbid="14411" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Senjuushi: Kijuushi-tachi no Happy Birthday!</name>
@@ -7306,14 +7273,8 @@
   <anime anidbid="14439" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Heya Camp</name>
   </anime>
-  <anime anidbid="14442" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Ore o Suki na no wa Omae Dake ka yo</name>
-  </anime>
   <anime anidbid="14443" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Donguri to Yamaneko (1995)</name>
-  </anime>
-  <anime anidbid="14445" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Rifle Is Beautiful</name>
   </anime>
   <anime anidbid="14446" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Doraemon: Nobita no Getsumen Tansaki</name>
@@ -7390,20 +7351,11 @@
   <anime anidbid="14483" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Dorohedoro</name>
   </anime>
-  <anime anidbid="14484" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Wagaya no Liliana-san The Animation</name>
-  </anime>
   <anime anidbid="14485" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tsukiuta. The Animation 2</name>
   </anime>
-  <anime anidbid="14486" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Actors: Songs Connection</name>
-  </anime>
   <anime anidbid="14492" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Goman-hiki</name>
-  </anime>
-  <anime anidbid="14495" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Gundam Build Divers Re:Rise</name>
   </anime>
   <anime anidbid="14500" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kiskis! Wo de Nanyou shi Bohetang</name>
@@ -7450,26 +7402,17 @@
   <anime anidbid="14525" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Power Battle Watch Car</name>
   </anime>
-  <anime anidbid="14527" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Tsuma ga Kirei ni Natta Wake</name>
-  </anime>
   <anime anidbid="14529" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Takarasagashi no Natsuyasumi</name>
   </anime>
   <anime anidbid="14531" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Aggressive Retsuko: We Wish You a Metal Christmas</name>
   </anime>
-  <anime anidbid="14532" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Hello World</name>
-  </anime>
   <anime anidbid="14533" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Baby I Love You Daze</name>
   </anime>
   <anime anidbid="14535" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hachi-nan tte, Sore wa Nai deshou!</name>
-  </anime>
-  <anime anidbid="14536" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Yue ni Hitozuma wa Netorareta.</name>
   </anime>
   <anime anidbid="14537" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Umayon</name>
@@ -7612,9 +7555,6 @@
   <anime anidbid="14617" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Nogsaegjeoncha Hamos</name>
   </anime>
-  <anime anidbid="14618" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Hataage! Kemono Michi</name>
-  </anime>
   <anime anidbid="14619" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>B Rappers Street</name>
   </anime>
@@ -7675,9 +7615,6 @@
   <anime anidbid="14647" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hua Jianghu: Buliang Ren Di San Ji</name>
   </anime>
-  <anime anidbid="14648" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Super Shiro</name>
-  </anime>
   <anime anidbid="14649" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wu Dong Qiankun</name>
   </anime>
@@ -7704,9 +7641,6 @@
   </anime>
   <anime anidbid="14657" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Qing Chi Hong Xiaodou Ba! Di Er Ji</name>
-  </anime>
-  <anime anidbid="14658" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Shin Chuuka Ichiban!</name>
   </anime>
   <anime anidbid="14665" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Move to the Future</name>
@@ -7756,9 +7690,6 @@
   <anime anidbid="14682" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Pandora to Akubi</name>
   </anime>
-  <anime anidbid="14683" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Eiga Sumikko Gurashi: Tobidasu Ehon to Himitsu no Ko</name>
-  </anime>
   <anime anidbid="14684" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Genji Fantasy: Neko ga Hikaru Genji ni Koi o Shita</name>
   </anime>
@@ -7789,14 +7720,8 @@
   <anime anidbid="14705" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Rainbow Ruby</name>
   </anime>
-  <anime anidbid="14706" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Mayonaka no Occult Koumuin: Fukurokouji to Anoko to Ore to</name>
-  </anime>
   <anime anidbid="14707" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Koisuru Asteroid</name>
-  </anime>
-  <anime anidbid="14708" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Master Piece The Animation</name>
   </anime>
   <anime anidbid="14709" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Bakugan: Battle Planet</name>
@@ -7879,9 +7804,6 @@
   <anime anidbid="14743" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>JA Kumamoto Keizairen</name>
   </anime>
-  <anime anidbid="14744" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Phantasy Star Online 2: Episode Oracle</name>
-  </anime>
   <anime anidbid="14745" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Han Solo/Star Wars Story</name>
   </anime>
@@ -7918,9 +7840,6 @@
   <anime anidbid="14762" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ahare! Meisaku-kun (2019)</name>
   </anime>
-  <anime anidbid="14763" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Fragtime</name>
-  </anime>
   <anime anidbid="14764" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Yahari Ore no Seishun LoveCome wa Machigatte Iru. 3</name>
   </anime>
@@ -7951,14 +7870,8 @@
   <anime anidbid="14775" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Mang Huang Ji</name>
   </anime>
-  <anime anidbid="14777" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Keishichou Tokumu Bu Tokushu Kyouakuhan Taisaku Shitsu Dai Nana Ka: Tokunana</name>
-  </anime>
   <anime anidbid="14778" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>An tu! An tu!</name>
-  </anime>
-  <anime anidbid="14779" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Sora no Aosa o Shiru Hito yo</name>
   </anime>
   <anime anidbid="14781" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wo Jiao Bai Xiao Fei</name>
@@ -7974,12 +7887,6 @@
   </anime>
   <anime anidbid="14785" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Somali to Mori no Kamisama</name>
-  </anime>
-  <anime anidbid="14786" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Thunderbolt Fantasy: Seiyuu Genka</name>
-  </anime>
-  <anime anidbid="14787" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Human Lost</name>
   </anime>
   <anime anidbid="14788" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Number 24</name>
@@ -8008,17 +7915,11 @@
   <anime anidbid="14800" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Oyako Nezumi no Fushigi na Tabi</name>
   </anime>
-  <anime anidbid="14802" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Bang Dream! Film Live</name>
-  </anime>
   <anime anidbid="14803" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Vampire</name>
   </anime>
   <anime anidbid="14804" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Uchuu Senkan Yamato 2205: Aratanaru Tabidachi</name>
-  </anime>
-  <anime anidbid="14806" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Kaijuu Step Wandabada</name>
   </anime>
   <anime anidbid="14807" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Aihime Megohime</name>
@@ -8136,9 +8037,6 @@
   </anime>
   <anime anidbid="14855" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Si Hai Jing Qi</name>
-  </anime>
-  <anime anidbid="14858" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Tenka Hyakken: Meiji-kan e Youkoso!</name>
   </anime>
   <anime anidbid="14860" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Xie Wang Zhui Qi</name>
@@ -8263,9 +8161,6 @@
   <anime anidbid="14907" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eizouken ni wa Te o Dasu na!</name>
   </anime>
-  <anime anidbid="14908" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Val x Love</name>
-  </anime>
   <anime anidbid="14910" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Norakuro Ittouhei</name>
   </anime>
@@ -8326,9 +8221,6 @@
   <anime anidbid="14940" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Sabiiro no Armor</name>
   </anime>
-  <anime anidbid="14941" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Mob Psycho 100: Daiikkai Rei toka Soudansho Ian Ryokou - Kokoro Mitasu Iyashi no Tabi</name>
-  </anime>
   <anime anidbid="14942" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Power Battle Watch Car Season 2</name>
   </anime>
@@ -8337,9 +8229,6 @@
   </anime>
   <anime anidbid="14944" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wan Jie Xian Zong Di Er Ji</name>
-  </anime>
-  <anime anidbid="14946" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Santa Company: Christmas no Himitsu</name>
   </anime>
   <anime anidbid="14948" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ultraman 2</name>
@@ -8355,9 +8244,6 @@
   </anime>
   <anime anidbid="14954" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Chui Zhi Shi Jie</name>
-  </anime>
-  <anime anidbid="14956" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Ani ni Tsukeru Kusuri wa Nai! 3</name>
   </anime>
   <anime anidbid="14957" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Yatogame-chan Kansatsu Nikki 2</name>
@@ -8380,17 +8266,11 @@
   <anime anidbid="14963" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tong Ling Fei</name>
   </anime>
-  <anime anidbid="14965" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Strike Witches: Gekijouban 501 Butai Hasshin Shimasu!</name>
-  </anime>
   <anime anidbid="14966" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Vlad Love</name>
   </anime>
   <anime anidbid="14969" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ishuzoku Reviewers</name>
-  </anime>
-  <anime anidbid="14971" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Mini Yuri</name>
   </anime>
   <anime anidbid="14976" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Astro Boy: Tetsuwan Atom - 10-man Kounen no Raihousha - IGZA</name>
@@ -8415,9 +8295,6 @@
   </anime>
   <anime anidbid="14987" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>ID:Invaded</name>
-  </anime>
-  <anime anidbid="14989" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Kutsujoku</name>
   </anime>
   <anime anidbid="14990" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Great Pretender</name>
@@ -8452,9 +8329,6 @@
   <anime anidbid="15002" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Koi to Producer: Evol x Love</name>
   </anime>
-  <anime anidbid="15003" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Lupin Sansei: The First</name>
-  </anime>
   <anime anidbid="15004" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Han Hua Ri Ji</name>
   </anime>
@@ -8472,9 +8346,6 @@
   </anime>
   <anime anidbid="15009" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ninja Box</name>
-  </anime>
-  <anime anidbid="15010" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Sound &amp; Fury</name>
   </anime>
   <anime anidbid="15011" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Noid</name>
@@ -8509,18 +8380,6 @@
   <anime anidbid="15021" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hero Mask (2019)</name>
   </anime>
-  <anime anidbid="15022" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Naedoko Demon's Ground</name>
-  </anime>
-  <anime anidbid="15023" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Null Peta</name>
-  </anime>
-  <anime anidbid="15024" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Kandagawa Jet Girls</name>
-  </anime>
-  <anime anidbid="15025" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Shigokare: Ecchi na Joshi Daisei to Doki x2 Love Lesson!! The Animation</name>
-  </anime>
   <anime anidbid="15027" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Deluxe Da yo! Kaishain</name>
   </anime>
@@ -8536,17 +8395,11 @@
   <anime anidbid="15032" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>BeyWarriors: Cyborg</name>
   </anime>
-  <anime anidbid="15033" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Urashimasakatasen no Nichijou</name>
-  </anime>
   <anime anidbid="15034" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Aggressive Retsuko 3</name>
   </anime>
   <anime anidbid="15035" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Quanzhi Gaoshou zhi Dianfeng Rongyao</name>
-  </anime>
-  <anime anidbid="15036" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Bananya: Fushigi na Nakama-tachi</name>
   </anime>
   <anime anidbid="15037" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tower of God</name>
@@ -8569,17 +8422,11 @@
   <anime anidbid="15043" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Jumbagi: Hanbandoui Gongryong 3D</name>
   </anime>
-  <anime anidbid="15044" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>XL Joushi.</name>
-  </anime>
   <anime anidbid="15045" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Haikyuu!! Riku vs Kuu</name>
   </anime>
   <anime anidbid="15046" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wave!!</name>
-  </anime>
-  <anime anidbid="15047" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Aikatsu on Parade!</name>
   </anime>
   <anime anidbid="15048" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>A3! Season Autumn &amp; Winter</name>
@@ -8592,9 +8439,6 @@
   </anime>
   <anime anidbid="15051" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zetsubou no Kaibutsu</name>
-  </anime>
-  <anime anidbid="15052" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Subarashiki Kokka no Kizukikata</name>
   </anime>
   <anime anidbid="15053" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Battle of Clay 2019</name>
@@ -8620,12 +8464,6 @@
   <anime anidbid="15060" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Crayon Shin-chan: Gekitotsu! Rakugaki Kingdom to Hobo Yonin no Yuusha</name>
   </anime>
-  <anime anidbid="15061" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Aibeya The Animation</name>
-  </anime>
-  <anime anidbid="15062" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Love x Holic: Miwaku no Otome to Hakudaku Kankei The Animation</name>
-  </anime>
   <anime anidbid="15063" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Uzumaki</name>
   </anime>
@@ -8637,9 +8475,6 @@
   </anime>
   <anime anidbid="15066" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Girl X</name>
-  </anime>
-  <anime anidbid="15067" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Pocket Monsters (2019)</name>
   </anime>
   <anime anidbid="15068" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kkoma Sinseon Tao</name>
@@ -8661,12 +8496,6 @@
   </anime>
   <anime anidbid="15074" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kuuchuu Gunkan Atlantis</name>
-  </anime>
-  <anime anidbid="15075" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Go! Go! Atom</name>
-  </anime>
-  <anime anidbid="15076" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Egg Car</name>
   </anime>
   <anime anidbid="15077" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Usagi no Mofy (2012)</name>
@@ -8716,12 +8545,6 @@
   <anime anidbid="15092" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zenonzard: The Animation</name>
   </anime>
-  <anime anidbid="15093" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Valkyrie Hazard</name>
-  </anime>
-  <anime anidbid="15094" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Hitozuma, Mitsu to Niku</name>
-  </anime>
   <anime anidbid="15095" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Maou-jou de Oyasumi</name>
   </anime>
@@ -8736,9 +8559,6 @@
   </anime>
   <anime anidbid="15100" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Date a Bullet</name>
-  </anime>
-  <anime anidbid="15101" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Taeko no Nichijou</name>
   </anime>
   <anime anidbid="15102" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Given</name>
@@ -8758,32 +8578,14 @@
   <anime anidbid="15108" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Obsolete</name>
   </anime>
-  <anime anidbid="15109" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Mono no Kamisama Cocotama</name>
-  </anime>
   <anime anidbid="15110" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kengan Ashura 2nd Season</name>
   </anime>
   <anime anidbid="15111" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Dungeon ni Deai o Motomeru no wa Machigatte Iru Darouka: Familia Myth III</name>
   </anime>
-  <anime anidbid="15112" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Sylvanian Families: Mini Story - Clover</name>
-  </anime>
   <anime anidbid="15113" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gekijouban Kimetsu no Yaiba: Mugen Ressha Hen</name>
   </anime>
-  <anime anidbid="15114" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Nozoki Kanojo</name>
-  </anime>
-  <anime anidbid="15115" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Boku to Joi no Shinsatsu Nisshi The Animation</name>
-  </anime>
-  <anime anidbid="15116" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Shen Bing Xiao Jiang</name>
-  </anime>
-  <anime anidbid="15117" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Miki no Mikoto</name>
-  </anime>
 </anime-list>
-<!--2922 titles remaining-->
+<!--2856 titles remaining-->

--- a/anime-list-unknown.xml
+++ b/anime-list-unknown.xml
@@ -3309,7 +3309,28 @@
   <anime anidbid="14716" tvdbid="unknown" defaulttvdbseason="1">
     <name>Yichang Shengwu Jianwen Lu</name>
   </anime>
+  <anime anidbid="14806" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Kaijuu Step Wandabada</name>
+  </anime>
   <anime anidbid="14973" tvdbid="unknown" defaulttvdbseason="1">
     <name>Business Fish</name>
+  </anime>
+  <anime anidbid="15075" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Go! Go! Atom</name>
+  </anime>
+  <anime anidbid="15076" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Egg Car</name>
+  </anime>
+  <anime anidbid="15109" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Mono no Kamisama Cocotama</name>
+  </anime>
+  <anime anidbid="15112" tvdbid="unknown">
+    <name>Sylvanian Families: Mini Story - Clover</name>
+  </anime>
+  <anime anidbid="15116" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Shen Bing Xiao Jiang</name>
+  </anime>
+  <anime anidbid="15117" tvdbid="unknown" defaulttvdbseason="1">
+    <name>Miki no Mikoto</name>
   </anime>
 </anime-list>

--- a/anime-list.xml
+++ b/anime-list.xml
@@ -29103,7 +29103,7 @@
       <mapping anidbseason="0" tvdbseason="0">;1-4;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202, 637462">
+  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202,637462">
     <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
   </anime>
   <anime anidbid="14241" tvdbid="353244" defaulttvdbseason="1">

--- a/anime-list.xml
+++ b/anime-list.xml
@@ -27303,7 +27303,7 @@
   <anime anidbid="12512" tvdbid="hentai" defaulttvdbseason="1">
     <name>Saimin Class: Joshi Zen'in, Shiranai Uchi ni Ninshin Shitemashita</name>
   </anime>
-  <anime anidbid="12519" tvdbid="278626" defaulttvdbseason="0" episodeoffset="2" imdbid="tt6213810">
+  <anime anidbid="12519" tvdbid="353666" defaulttvdbseason="0" imdbid="tt6213810">
     <name>Fate/Grand Order: First Order</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -28504,10 +28504,10 @@
   <anime anidbid="13641" tvdbid="movie" defaulttvdbseason="1" tmdbid="466980" imdbid="tt7146054">
     <name>Dahufa</name>
   </anime>
-  <anime anidbid="13643" tvdbid="278626" defaulttvdbseason="0" episodeoffset="4">
+  <anime anidbid="13643" tvdbid="353666" defaulttvdbseason="0" episodeoffset="1" tmdbid="495907">
     <name>Fate/Grand Order: Moonlight/Lostroom</name>
   </anime>
-  <anime anidbid="13644" tvdbid="278626" defaulttvdbseason="0" episodeoffset="5">
+  <anime anidbid="13644" tvdbid="353666" defaulttvdbseason="0" episodeoffset="2" tmdbid="496432">
     <name>Fate/Grand Order x Himuro no Tenchi: 7-nin no Saikyou Ijin Hen</name>
   </anime>
   <anime anidbid="13649" tvdbid="76703" defaulttvdbseason="0" imdbid="tt8108230">
@@ -29099,6 +29099,12 @@
   </anime>
   <anime anidbid="14238" tvdbid="353666" defaulttvdbseason="1" imdbid="tt9525238">
     <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
+	<mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-4;</mapping>
+    </mapping-list>
+  </anime>
+  <anime anidbid="14239" tvdbid="353666" defaulttvdbseason="0" episodeoffset="5" tmdbid="637202, 637462">
+    <name>Gekijouban Fate/Grand Order: Shinsei Entaku Ryouiki Camelot</name>
   </anime>
   <anime anidbid="14241" tvdbid="353244" defaulttvdbseason="1">
     <name>Okoshiyasu, Chitose-chan</name>
@@ -29406,11 +29412,8 @@
   <anime anidbid="14574" tvdbid="361491" defaulttvdbseason="1" tmdbid="88050" imdbid="tt10347516">
     <name>Cop Craft</name>
   </anime>
-  <anime anidbid="14579" tvdbid="278626" defaulttvdbseason="0">
+  <anime anidbid="14579" tvdbid="353666" defaulttvdbseason="0" episodeoffset="3">
     <name>Manga de Wakaru! Fate/Grand Order</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-9;2-9;3-9;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="14580" tvdbid="357492" defaulttvdbseason="1" tmdbid="85368" imdbid="tt9573854">
     <name>Lord El-Melloi II-sei no Jikenbo: Rail Zeppelin Grace Note</name>

--- a/anime-list.xml
+++ b/anime-list.xml
@@ -29414,6 +29414,9 @@
   </anime>
   <anime anidbid="14579" tvdbid="353666" defaulttvdbseason="0" episodeoffset="3">
     <name>Manga de Wakaru! Fate/Grand Order</name>
+	<mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-4;2-4;3-4;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="14580" tvdbid="357492" defaulttvdbseason="1" tmdbid="85368" imdbid="tt9573854">
     <name>Lord El-Melloi II-sei no Jikenbo: Rail Zeppelin Grace Note</name>

--- a/anime-list.xml
+++ b/anime-list.xml
@@ -27870,6 +27870,9 @@
   <anime anidbid="13106" tvdbid="293121" defaulttvdbseason="2">
     <name>Himouto! Umaru-chan R</name>
   </anime>
+  <anime anidbid="13108" tvdbid="283929" defaulttvdbseason="0" episodeoffset="10">
+    <name>Gekijouban Gundam G no Reconguista</name>
+  </anime>
   <anime anidbid="13114" tvdbid="332987" defaulttvdbseason="1">
     <name>Anime-Gataris</name>
   </anime>
@@ -28260,6 +28263,9 @@
   </anime>
   <anime anidbid="13440" tvdbid="353219" defaulttvdbseason="1">
     <name>Gaikotsu Shoten'in Honda-san</name>
+  </anime>
+  <anime anidbid="13441" tvdbid="353455" defaulttvdbseason="1" imdbid="tt11070000">
+    <name>Z/X: Code Reunion</name>
   </anime>
   <anime anidbid="13469" tvdbid="328670" defaulttvdbseason="2">
     <name>Quanzhi Fashi 2</name>
@@ -28676,6 +28682,9 @@
   <anime anidbid="13843" tvdbid="85192" defaulttvdbseason="3">
     <name>Souten no Ken: Regenesis (2018)</name>
   </anime>
+  <anime anidbid="13844" tvdbid="368861" defaulttvdbseason="1" imdbid="tt10882992">
+    <name>Watashi, Nouryoku wa Heikinchi dette Itta yo ne!</name>
+  </anime>
   <anime anidbid="13845" tvdbid="347578" defaulttvdbseason="1">
     <name>Zoids Wild</name>
   </anime>
@@ -28684,6 +28693,9 @@
   </anime>
   <anime anidbid="13848" tvdbid="365720" defaulttvdbseason="1">
     <name>Ahiru no Sora</name>
+  </anime>
+  <anime anidbid="13849" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Dokidoki Little Ooyasan</name>
   </anime>
   <anime anidbid="13859" tvdbid="326337" defaulttvdbseason="3">
     <name>Idolmaster Cinderella Girls Gekijou (2018)</name>
@@ -28743,6 +28755,9 @@
   <anime anidbid="13914" tvdbid="325374" defaulttvdbseason="2">
     <name>Duel Masters!</name>
   </anime>
+  <anime anidbid="13915" tvdbid="ova" defaulttvdbseason="1">
+    <name>Bean Bandit</name>
+  </anime>
   <anime anidbid="13916" tvdbid="347467" defaulttvdbseason="1">
     <name>Muhyo to Roji no Mahouritsu Soudan Jimusho</name>
   </anime>
@@ -28754,6 +28769,9 @@
   </anime>
   <anime anidbid="13923" tvdbid="345100" defaulttvdbseason="1">
     <name>Double Decker! Doug &amp; Kirill</name>
+  </anime>
+  <anime anidbid="13924" tvdbid="movie" defaulttvdbseason="1" imdbid="tt8816016">
+    <name>Black Fox</name>
   </anime>
   <anime anidbid="13925" tvdbid="351751" defaulttvdbseason="1">
     <name>Irozuku Sekai no Ashita kara</name>
@@ -28857,11 +28875,17 @@
   <anime anidbid="14039" tvdbid="293647" defaulttvdbseason="5">
     <name>Ame-iro Cocoa: Side G</name>
   </anime>
+  <anime anidbid="14041" tvdbid="movie" defaulttvdbseason="1" tmdbid="6356813">
+    <name>Kimi dake ni Motetainda.</name>
+  </anime>
   <anime anidbid="14042" tvdbid="142601" defaulttvdbseason="0" episodeoffset="9">
     <name>Kidou Senshi Gundam Narrative</name>
   </anime>
   <anime anidbid="14044" tvdbid="348719" defaulttvdbseason="1">
     <name>Aguu: Tensai Ningyou</name>
+  </anime>
+  <anime anidbid="14047" tvdbid="250022" defaulttvdbseason="0" episodeoffset="9">
+    <name>Yuru Yuri Ten</name>
   </anime>
   <anime anidbid="14049" tvdbid="320002" defaulttvdbseason="0" episodeoffset="1">
     <name>Pastel Life</name>
@@ -29073,6 +29097,9 @@
   <anime anidbid="14237" tvdbid="353579" defaulttvdbseason="1">
     <name>Ken En Ken: Aoki Kagayaki</name>
   </anime>
+  <anime anidbid="14238" tvdbid="353666" defaulttvdbseason="1" imdbid="tt9525238">
+    <name>Fate/Grand Order: Zettai Majuu Sensen Babylonia</name>
+  </anime>
   <anime anidbid="14241" tvdbid="353244" defaulttvdbseason="1">
     <name>Okoshiyasu, Chitose-chan</name>
   </anime>
@@ -29151,6 +29178,9 @@
   <anime anidbid="14396" tvdbid="367277" defaulttvdbseason="1">
     <name>Azur Lane the Animation</name>
   </anime>
+  <anime anidbid="14398" tvdbid="361439" defaulttvdbseason="1" tmdbid="93818">
+    <name>Stand My Heroes: Piece of Truth</name>
+  </anime>
   <anime anidbid="14399" tvdbid="hentai" defaulttvdbseason="1">
     <name>Rape Gouhouka!!!</name>
   </anime>
@@ -29162,6 +29192,9 @@
   </anime>
   <anime anidbid="14406" tvdbid="281253" defaulttvdbseason="0">
     <name>Majimoji Rurumo: Kanketsuhen</name>
+  </anime>
+  <anime anidbid="14410" tvdbid="368366" defaulttvdbseason="1" imdbid="tt11033998">
+    <name>Chuubyou Gekihatsu Boy</name>
   </anime>
   <anime anidbid="14412" tvdbid="353608" defaulttvdbseason="1">
     <name>Otona no Bouguya-san</name>
@@ -29196,8 +29229,14 @@
   <anime anidbid="14441" tvdbid="114921" defaulttvdbseason="3">
     <name>Toaru Kagaku no Railgun T</name>
   </anime>
+  <anime anidbid="14442" tvdbid="368862" defaulttvdbseason="1" imdbid="tt10883006">
+    <name>Ore o Suki na no wa Omae Dake ka yo</name>
+  </anime>
   <anime anidbid="14444" tvdbid="267440" defaulttvdbseason="3" episodeoffset="12">
     <name>Shingeki no Kyojin Season 3 (2019)</name>
+  </anime>
+  <anime anidbid="14445" tvdbid="367513" defaulttvdbseason="1" imdbid="tt10707854">
+    <name>Rifle Is Beautiful</name>
   </anime>
   <anime anidbid="14447" tvdbid="354675" defaulttvdbseason="1">
     <name>Egao no Daika</name>
@@ -29232,6 +29271,12 @@
   <anime anidbid="14480" tvdbid="313185" defaulttvdbseason="0" episodeoffset="1">
     <name>Final Fantasy XV: Episode Ardyn - Prologue</name>
   </anime>
+  <anime anidbid="14484" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Wagaya no Liliana-san The Animation</name>
+  </anime>
+  <anime anidbid="14486" tvdbid="369801" defaulttvdbseason="1" tmdbid="93819">
+    <name>Actors: Songs Connection</name>
+  </anime>
   <anime anidbid="14487" tvdbid="357448" defaulttvdbseason="0" episodeoffset="1" imdbid="tt10037700">
     <name>Eiga Precure Miracle Universe</name>
   </anime>
@@ -29252,6 +29297,9 @@
   </anime>
   <anime anidbid="14494" tvdbid="294002" defaulttvdbseason="0" episodeoffset="39">
     <name>Ple Ple Pleiades: Clementine Toubou Hen</name>
+  </anime>
+  <anime anidbid="14495" tvdbid="369139" defaulttvdbseason="1" imdbid="tt11100658">
+    <name>Gundam Build Divers Re:Rise</name>
   </anime>
   <anime anidbid="14496" tvdbid="319976" defaulttvdbseason="1">
     <name>Kidou Senshi Gundam: The Origin - Zen'ya Akai Suisei</name>
@@ -29295,14 +29343,23 @@
   <anime anidbid="14526" tvdbid="352408" defaulttvdbseason="0" episodeoffset="1">
     <name>Tensei Shitara Slime Datta Ken (2019)</name>
   </anime>
+  <anime anidbid="14527" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Tsuma ga Kirei ni Natta Wake</name>
+  </anime>
   <anime anidbid="14528" tvdbid="356486" defaulttvdbseason="1">
     <name>Papa Datte, Shitai</name>
   </anime>
   <anime anidbid="14530" tvdbid="359836" defaulttvdbseason="1">
     <name>Nobunaga-sensei no Osanazuma</name>
   </anime>
+  <anime anidbid="14532" tvdbid="movie" defaulttvdbseason="1" imdbid="tt9418812">
+    <name>Hello World</name>
+  </anime>
   <anime anidbid="14534" tvdbid="movie" defaulttvdbseason="1" imdbid="tt9426210">
     <name>Tenki no Ko</name>
+  </anime>
+  <anime anidbid="14536" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Yue ni Hitozuma wa Netorareta.</name>
   </anime>
   <anime anidbid="14543" tvdbid="358425" defaulttvdbseason="1">
     <name>Idolish Seven: Vibrato</name>
@@ -29385,6 +29442,9 @@
   <anime anidbid="14603" tvdbid="360502" defaulttvdbseason="1" imdbid="tt10362632">
     <name>Dumbbell Nan Kilo Moteru?</name>
   </anime>
+  <anime anidbid="14618" tvdbid="368905" defaulttvdbseason="1" imdbid="tt9635464">
+    <name>Hataage! Kemono Michi</name>
+  </anime>
   <anime anidbid="14623" tvdbid="347215" defaulttvdbseason="2">
     <name>Jashin-chan Dropkick 2</name>
   </anime>
@@ -29405,6 +29465,12 @@
   </anime>
   <anime anidbid="14639" tvdbid="362432" defaulttvdbseason="1">
     <name>Ling Jian Zun</name>
+  </anime>
+  <anime anidbid="14648" tvdbid="370951" defaulttvdbseason="1" imdbid="tt9845246">
+    <name>Super Shiro</name>
+  </anime>
+  <anime anidbid="14658" tvdbid="370891" defaulttvdbseason="1" tmdbid="94500">
+    <name>Shin Chuuka Ichiban!</name>
   </anime>
   <anime anidbid="14659" tvdbid="361013" defaulttvdbseason="1">
     <name>Beastars</name>
@@ -29429,6 +29495,9 @@
   </anime>
   <anime anidbid="14679" tvdbid="movie" defaulttvdbseason="1" tmdbid="594188" imdbid="tt9760504">
     <name>Ni no Kuni</name>
+  </anime>
+  <anime anidbid="14683" tvdbid="movie" defaulttvdbseason="1" tmdbid="636959">
+    <name>Eiga Sumikko Gurashi: Tobidasu Ehon to Himitsu no Ko</name>
   </anime>
   <anime anidbid="14685" tvdbid="movie" defaulttvdbseason="1" tmdbid="592867" imdbid="tt10127562">
     <name>Dragon Quest: Your Story</name>
@@ -29457,6 +29526,12 @@
   <anime anidbid="14701" tvdbid="342131" defaulttvdbseason="2">
     <name>Radiant (2019)</name>
   </anime>
+  <anime anidbid="14706" tvdbid="358331" defaulttvdbseason="0" episodeoffset="1">
+    <name>Mayonaka no Occult Koumuin: Fukurokouji to Anoko to Ore to</name>
+  </anime>
+  <anime anidbid="14708" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Master Piece The Animation</name>
+  </anime>
   <anime anidbid="14710" tvdbid="362052" defaulttvdbseason="1" imdbid="tt10427920">
     <name>Sounan Desuka?</name>
   </anime>
@@ -29474,6 +29549,9 @@
   </anime>
   <anime anidbid="14736" tvdbid="ova" defaulttvdbseason="1" tmdbid="587873">
     <name>Totsukuni no Shoujo</name>
+  </anime>
+  <anime anidbid="14744" tvdbid="370895" defaulttvdbseason="1" imdbid="tt10814346">
+    <name>Phantasy Star Online 2: Episode Oracle</name>
   </anime>
   <anime anidbid="14749" tvdbid="hentai" defaulttvdbseason="1">
     <name>Sakuramiya Shimai no Netorare Kiroku</name>
@@ -29493,14 +29571,29 @@
   <anime anidbid="14759" tvdbid="367067" defaulttvdbseason="1">
     <name>No Guns Life</name>
   </anime>
+  <anime anidbid="14763" tvdbid="movie" defaulttvdbseason="1" tmdbid="630027">
+    <name>Fragtime</name>
+  </anime>
   <anime anidbid="14773" tvdbid="web" defaulttvdbseason="1">
     <name>Ero Lover</name>
   </anime>
   <anime anidbid="14776" tvdbid="305074" defaulttvdbseason="0" episodeoffset="6">
     <name>Boku no Hero Academia the Movie: Heroes:Rising</name>
   </anime>
+  <anime anidbid="14777" tvdbid="368757" defaulttvdbseason="1" imdbid="tt10054654">
+    <name>Keishichou Tokumu Bu Tokushu Kyouakuhan Taisaku Shitsu Dai Nana Ka: Tokunana</name>
+  </anime>
+  <anime anidbid="14779" tvdbid="movie" defaulttvdbseason="1" imdbid="tt10981202">
+    <name>Sora no Aosa o Shiru Hito yo</name>
+  </anime>
   <anime anidbid="14780" tvdbid="346673" defaulttvdbseason="2">
     <name>High Score Girl II</name>
+  </anime>
+  <anime anidbid="14786" tvdbid="movie" defaulttvdbseason="1">
+    <name>Thunderbolt Fantasy: Seiyuu Genka</name>
+  </anime>
+  <anime anidbid="14787" tvdbid="movie" imdbid="tt10622220">
+    <name>Human Lost</name>
   </anime>
   <anime anidbid="14791" tvdbid="346931" defaulttvdbseason="2">
     <name>Hataraku Saibou 2</name>
@@ -29516,6 +29609,9 @@
   </anime>
   <anime anidbid="14801" tvdbid="348002" defaulttvdbseason="2">
     <name>Yakusoku no Neverland (2020)</name>
+  </anime>
+  <anime anidbid="14802" tvdbid="320002" defaulttvdbseason="0" episodeoffset="11" imdbid="tt11056458">
+    <name>Bang Dream! Film Live</name>
   </anime>
   <anime anidbid="14805" tvdbid="366358" defaulttvdbseason="1" tmdbid="90847">
     <name>Hakata Mentai! Pirikarako-chan</name>
@@ -29544,6 +29640,9 @@
   <anime anidbid="14857" tvdbid="319997" defaulttvdbseason="0" episodeoffset="4">
     <name>Chokotto Anime Kemono Friends 3</name>
   </anime>
+  <anime anidbid="14858" tvdbid="369749" defaulttvdbseason="1" tmdbid="93828">
+    <name>Tenka Hyakken: Meiji-kan e Youkoso!</name>
+  </anime>
   <anime anidbid="14875" tvdbid="311607" defaulttvdbseason="2">
     <name>Flowering Heart 2</name>
   </anime>
@@ -29558,6 +29657,9 @@
   </anime>
   <anime anidbid="14906" tvdbid="hentai" defaulttvdbseason="1">
     <name>Ochi Mono RPG Seikishi Luvilias</name>
+  </anime>
+  <anime anidbid="14908" tvdbid="366706" defaulttvdbseason="1" imdbid="tt10974256">
+    <name>Val x Love</name>
   </anime>
   <anime anidbid="14909" tvdbid="hentai" defaulttvdbseason="1">
     <name>Joshi Luck!</name>
@@ -29589,17 +29691,32 @@
   <anime anidbid="14924" tvdbid="hentai" defaulttvdbseason="1">
     <name>Yubisaki kara Honki no Netsujou: Osananajimi wa Shouboushi</name>
   </anime>
+  <anime anidbid="14941" tvdbid="307375" defaulttvdbseason="0" episodeoffset="7">
+    <name>Mob Psycho 100: Daiikkai Rei toka Soudansho Ian Ryokou - Kokoro Mitasu Iyashi no Tabi</name>
+  </anime>
+  <anime anidbid="14946" tvdbid="movie" defaulttvdbseason="1" imdbid="tt10476540">
+    <name>Santa Company: Christmas no Himitsu</name>
+  </anime>
   <anime anidbid="14951" tvdbid="289909" defaulttvdbseason="4">
     <name>Shokugeki no Souma: Shin no Sara</name>
   </anime>
+  <anime anidbid="14956" tvdbid="327261" defaulttvdbseason="3">
+    <name>Ani ni Tsukeru Kusuri wa Nai! 3</name>
+  </anime>
   <anime anidbid="14964" tvdbid="357471" defaulttvdbseason="2">
     <name>Isekai Quartet 2</name>
+  </anime>
+  <anime anidbid="14965" tvdbid="361217" defaulttvdbseason="0" tmdbid="632088">
+    <name>Strike Witches: Gekijouban 501 Butai Hasshin Shimasu!</name>
   </anime>
   <anime anidbid="14968" tvdbid="359095" defaulttvdbseason="2">
     <name>Bokutachi wa Benkyou ga Dekinai!</name>
   </anime>
   <anime anidbid="14970" tvdbid="movie" defaulttvdbseason="1">
     <name>Cencoroll 3</name>
+  </anime>
+  <anime anidbid="14971" tvdbid="250022" defaulttvdbseason="0" episodeoffset="4">
+    <name>Mini Yuri</name>
   </anime>
   <anime anidbid="14972" tvdbid="366357" defaulttvdbseason="1">
     <name>Waresho! Warera! Shoudoubutsu Aigo Iinkai</name>
@@ -29625,13 +29742,73 @@
   <anime anidbid="14988" tvdbid="357488" defaulttvdbseason="2">
     <name>Fruits Basket 2nd Season</name>
   </anime>
+  <anime anidbid="14989" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Kutsujoku</name>
+  </anime>
   <anime anidbid="14995" tvdbid="338455" defaulttvdbseason="3">
     <name>Golden Kamuy 3</name>
+  </anime>
+  <anime anidbid="15003" tvdbid="movie" defaulttvdbseason="1" imdbid="tt10621032">
+    <name>Lupin Sansei: The First</name>
+  </anime>
+  <anime anidbid="15010" tvdbid="web" defaulttvdbseason="1" imdbid="tt10682000">
+    <name>Sound &amp; Fury</name>
+  </anime>
+  <anime anidbid="15022" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Naedoko Demon's Ground</name>
+  </anime>
+  <anime anidbid="15023" tvdbid="369145" defaulttvdbseason="1" tmdbid="91587">
+    <name>Null Peta</name>
+  </anime>
+  <anime anidbid="15024" tvdbid="369146" defaulttvdbseason="1" imdbid="tt10978032">
+    <name>Kandagawa Jet Girls</name>
+  </anime>
+  <anime anidbid="15025" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Shigokare: Ecchi na Joshi Daisei to Doki x2 Love Lesson!! The Animation</name>
   </anime>
   <anime anidbid="15026" tvdbid="347578" defaulttvdbseason="2">
     <name>Zoids Wild Zero</name>
   </anime>
   <anime anidbid="15028" tvdbid="351953" defaulttvdbseason="2">
     <name>Zombie Land Saga Revenge</name>
+  </anime>
+  <anime anidbid="15033" tvdbid="370373" defaulttvdbseason="1" tmdbid="94214">
+    <name>Urashimasakatasen no Nichijou</name>
+  </anime>
+  <anime anidbid="15036" tvdbid="313676" defaulttvdbseason="2" tmdbid="94190">
+    <name>Bananya: Fushigi na Nakama-tachi</name>
+  </anime>
+  <anime anidbid="15044" tvdbid="hentai" defaulttvdbseason="1">
+    <name>XL Joushi.</name>
+  </anime>
+  <anime anidbid="15047" tvdbid="370508" defaulttvdbseason="1" tmdbid="94313">
+    <name>Aikatsu on Parade!</name>
+  </anime>
+  <anime anidbid="15052" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Subarashiki Kokka no Kizukikata</name>
+  </anime>
+  <anime anidbid="15061" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Aibeya The Animation</name>
+  </anime>
+  <anime anidbid="15062" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Love x Holic: Miwaku no Otome to Hakudaku Kankei The Animation</name>
+  </anime>
+  <anime anidbid="15067" tvdbid="76703" defaulttvdbseason="19">
+    <name>Pocket Monsters (2019)</name>
+  </anime>
+  <anime anidbid="15093" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Valkyrie Hazard</name>
+  </anime>
+  <anime anidbid="15094" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Hitozuma, Mitsu to Niku</name>
+  </anime>
+  <anime anidbid="15101" tvdbid="370501" defaulttvdbseason="1" tmdbid="94299">
+    <name>Taeko no Nichijou</name>
+  </anime>
+  <anime anidbid="15114" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Nozoki Kanojo</name>
+  </anime>
+  <anime anidbid="15115" tvdbid="hentai" defaulttvdbseason="1">
+    <name>Boku to Joi no Shinsatsu Nisshi The Animation</name>
   </anime>
 </anime-list>


### PR DESCRIPTION
This should largely finish up the mappings for the Fall 2019 season.

Note that I am pretty much basing this off of the [AniDB Season Chart](https://anidb.net/anime/season/?do.filter=1) as it was on **2019/10/03**. 

I did a quick comparison between the **animetitles.xml** from then and the one currently used by the anime-lists, and included the newest series added at the end, but I know there are at least a handful of entries on AniDB that were not yet included in the latest **animetitles.xml** on GH (One 18+ OVA, and an unknown number of regular entries).

PS: See commit comment for list of entries mapped, alongside their AniDB-ID.