### PR TITLE
Added Honzuki no Gekokujou (2020) TVDB mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -42041,7 +42041,7 @@
   <anime anidbid="15292" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Dajiao Niu Meng Gongchang</name>
   </anime>
-  <anime anidbid="15293" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15293" tvdbid="366263" defaulttvdbseason="1" episodeoffset="14" tmdbid="" imdbid="">
     <name>Honzuki no Gekokujou: Shisho ni Naru Tame ni wa Shudan o Erande Iraremasen (2020)</name>
   </anime>
   <anime anidbid="15294" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Added the TVDB mapping for the 2nd season of **Honzuki no Gekokujou**. [TVDB](https://thetvdb.com/series/ascendance-of-a-bookworm/seasons/official/1) has it as a continuation of the first season so **episodeoffset** used.