### PR TITLE
added/updated some entries

### DIFF
--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -913,7 +913,7 @@
       <mapping anidbseason="0" tvdbseason="0" start="1" end="2" offset="1">;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="202" tvdbid="70350" defaulttvdbseason="0" episodeoffset="1" imdbid="tt0169858">
+  <anime anidbid="202" tvdbid="70350" defaulttvdbseason="0" episodeoffset="2" imdbid="tt0169858">
     <name>Shinseiki Evangelion Gekijouban: Air / Magokoro o, Kimi ni</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -13921,7 +13921,7 @@
   <anime anidbid="4845" tvdbid="258961" defaulttvdbseason="1">
     <name>Nanako SOS</name>
   </anime>
-  <anime anidbid="4847" tvdbid="70350" defaulttvdbseason="0" episodeoffset="2" imdbid="tt0923811">
+  <anime anidbid="4847" tvdbid="70350" defaulttvdbseason="0" episodeoffset="3" imdbid="tt0923811">
     <name>Evangelion Shin Gekijouban: Jo</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -14629,10 +14629,6 @@
   </anime>
   <anime anidbid="5101" tvdbid="80644" defaulttvdbseason="1">
     <name>Clannad</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="1">;1-23;</mapping>
-    </mapping-list>
-    <before>;1-23;</before>
   </anime>
   <anime anidbid="5104" tvdbid="79156" defaulttvdbseason="0" imdbid="tt1135522">
     <name>Shin Kyuuseishu Densetsu Hokuto no Ken Raou-den Gekitou no Shou</name>
@@ -16837,7 +16833,7 @@
       <mapping anidbseason="0" tvdbseason="0">;1-2;2-3;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="6171" tvdbid="70350" defaulttvdbseason="0" episodeoffset="3" imdbid="tt0860906">
+  <anime anidbid="6171" tvdbid="70350" defaulttvdbseason="0" episodeoffset="4" imdbid="tt0860906">
     <name>Evangelion Shin Gekijouban: Ha</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -17293,11 +17289,6 @@
   </anime>
   <anime anidbid="6367" tvdbid="79414" defaulttvdbseason="1">
     <name>Suzumiya Haruhi no Yuuutsu (2009)</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
-      <mapping anidbseason="1" tvdbseason="1">;1-2;2-3;3-5;4-10;5-13;6-14;7-4;9-7;10-6;11-8;25-1;26-12;27-11;28-9;</mapping>
-      <mapping anidbseason="1" tvdbseason="2">;8-1;12-2;13-3;14-4;15-5;16-6;17-7;18-8;19-9;20-10;21-11;22-12;23-13;24-14;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="6368" tvdbid="hentai" defaulttvdbseason="1">
     <name>Nudlnude</name>
@@ -20510,7 +20501,7 @@
   <anime anidbid="7564" tvdbid="164741" defaulttvdbseason="0" imdbid="unknown">
     <name>Ninja Hattori-kun: Nin Nin Ninpo Enikki no Maki</name>
   </anime>
-  <anime anidbid="7565" tvdbid="70350" defaulttvdbseason="0" episodeoffset="4" imdbid="tt0860907">
+  <anime anidbid="7565" tvdbid="70350" defaulttvdbseason="0" episodeoffset="5" imdbid="tt0860907">
     <name>Evangelion Shin Gekijouban: Q</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -28343,7 +28334,7 @@
   <anime anidbid="10936" tvdbid="289903" defaulttvdbseason="1">
     <name>Kyoukai no Rinne</name>
   </anime>
-  <anime anidbid="10937" tvdbid="328719" defaulttvdbseason="1" imdbid="tt5323662">
+  <anime anidbid="10937" tvdbid="movie" defaulttvdbseason="1" imdbid="tt5323662">
     <name>Eiga Koe no Katachi</name>
   </anime>
   <anime anidbid="10938" tvdbid="295243" defaulttvdbseason="1">
@@ -31404,6 +31395,9 @@
   <anime anidbid="13362" tvdbid="339276" defaulttvdbseason="1">
     <name>Hakumei to Mikochi</name>
   </anime>
+  <anime anidbid="13363" tvdbid="movie" defaulttvdbseason="1" imdbid="tt7236034">
+    <name>Kimi no Suizou o Tabetai</name>
+  </anime>
   <anime anidbid="13376" tvdbid="337015" defaulttvdbseason="1">
     <name>Takunomi.</name>
   </anime>
@@ -31463,6 +31457,12 @@
   </anime>
   <anime anidbid="13426" tvdbid="344222" defaulttvdbseason="1">
     <name>Uchuu Senkan Tiramisu</name>
+  </anime>
+  <anime anidbid="13430" tvdbid="305089" defaulttvdbseason="0">
+    <name>Re:Zero kara Hajimeru Isekai Seikatsu (2018)</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-26;2-28;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="13434" tvdbid="340011" defaulttvdbseason="1">
     <name>Hinamatsuri (2018)</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -913,7 +913,7 @@
       <mapping anidbseason="0" tvdbseason="0" start="1" end="2" offset="1">;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="202" tvdbid="70350" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="tt0169858">
+  <anime anidbid="202" tvdbid="70350" defaulttvdbseason="0" episodeoffset="2" tmdbid="" imdbid="tt0169858">
     <name>Shinseiki Evangelion Gekijouban: Air / Magokoro o, Kimi ni</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -13996,7 +13996,7 @@
   <anime anidbid="4845" tvdbid="258961" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Nanako SOS</name>
   </anime>
-  <anime anidbid="4847" tvdbid="70350" defaulttvdbseason="0" episodeoffset="2" tmdbid="" imdbid="tt0923811">
+  <anime anidbid="4847" tvdbid="70350" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="tt0923811">
     <name>Evangelion Shin Gekijouban: Jo</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -14704,10 +14704,6 @@
   </anime>
   <anime anidbid="5101" tvdbid="80644" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Clannad</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="1">;1-23;</mapping>
-    </mapping-list>
-    <before>;1-23;</before>
   </anime>
   <anime anidbid="5104" tvdbid="79156" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt1135522">
     <name>Shin Kyuuseishu Densetsu Hokuto no Ken Raou-den Gekitou no Shou</name>
@@ -16924,7 +16920,7 @@
       <mapping anidbseason="0" tvdbseason="0">;1-2;2-3;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="6171" tvdbid="70350" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="tt0860906">
+  <anime anidbid="6171" tvdbid="70350" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="tt0860906">
     <name>Evangelion Shin Gekijouban: Ha</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -17386,11 +17382,6 @@
   </anime>
   <anime anidbid="6367" tvdbid="79414" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Suzumiya Haruhi no Yuuutsu (2009)</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
-      <mapping anidbseason="1" tvdbseason="1">;1-2;2-3;3-5;4-10;5-13;6-14;7-4;9-7;10-6;11-8;25-1;26-12;27-11;28-9;</mapping>
-      <mapping anidbseason="1" tvdbseason="2">;8-1;12-2;13-3;14-4;15-5;16-6;17-7;18-8;19-9;20-10;21-11;22-12;23-13;24-14;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="6368" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Nudlnude</name>
@@ -20807,7 +20798,7 @@
   <anime anidbid="7564" tvdbid="164741" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="unknown">
     <name>Ninja Hattori-kun: Nin Nin Ninpo Enikki no Maki</name>
   </anime>
-  <anime anidbid="7565" tvdbid="70350" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="tt0860907">
+  <anime anidbid="7565" tvdbid="70350" defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="tt0860907">
     <name>Evangelion Shin Gekijouban: Q</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -30026,7 +30017,7 @@
   <anime anidbid="10936" tvdbid="289903" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kyoukai no Rinne</name>
   </anime>
-  <anime anidbid="10937" tvdbid="328719" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt5323662">
+  <anime anidbid="10937" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt5323662">
     <name>Eiga Koe no Katachi</name>
   </anime>
   <anime anidbid="10938" tvdbid="295243" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -36636,7 +36627,7 @@
   <anime anidbid="13362" tvdbid="339276" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Hakumei to Mikochi</name>
   </anime>
-  <anime anidbid="13363" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13363" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt7236034">
     <name>Kimi no Suizou o Tabetai</name>
   </anime>
   <anime anidbid="13364" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -36828,8 +36819,11 @@
   <anime anidbid="13429" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lan Mo De Hua</name>
   </anime>
-  <anime anidbid="13430" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13430" tvdbid="305089" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Re:Zero kara Hajimeru Isekai Seikatsu (2018)</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-26;2-28;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="13431" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Glamorous Heroes</name>

--- a/anime-list-todo.xml
+++ b/anime-list-todo.xml
@@ -5251,9 +5251,6 @@
   <anime anidbid="13361" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lostorage Conflated WIXOSS: Missing Link - Yochou / Yoake to Mimei</name>
   </anime>
-  <anime anidbid="13363" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Kimi no Suizou o Tabetai</name>
-  </anime>
   <anime anidbid="13364" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>A Smart Experiment</name>
   </anime>
@@ -5382,9 +5379,6 @@
   </anime>
   <anime anidbid="13429" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lan Mo De Hua</name>
-  </anime>
-  <anime anidbid="13430" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
-    <name>Re:Zero kara Hajimeru Isekai Seikatsu (2018)</name>
   </anime>
   <anime anidbid="13431" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Glamorous Heroes</name>
@@ -9533,4 +9527,4 @@
     <name>Ling Long: Incarnation</name>
   </anime>
 </anime-list>
-<!--3171 titles remaining-->
+<!--3169 titles remaining-->

--- a/anime-list.xml
+++ b/anime-list.xml
@@ -913,7 +913,7 @@
       <mapping anidbseason="0" tvdbseason="0" start="1" end="2" offset="1">;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="202" tvdbid="70350" defaulttvdbseason="0" episodeoffset="1" imdbid="tt0169858">
+  <anime anidbid="202" tvdbid="70350" defaulttvdbseason="0" episodeoffset="2" imdbid="tt0169858">
     <name>Shinseiki Evangelion Gekijouban: Air / Magokoro o, Kimi ni</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -12190,7 +12190,7 @@
   <anime anidbid="4845" tvdbid="258961" defaulttvdbseason="1">
     <name>Nanako SOS</name>
   </anime>
-  <anime anidbid="4847" tvdbid="70350" defaulttvdbseason="0" episodeoffset="2" imdbid="tt0923811">
+  <anime anidbid="4847" tvdbid="70350" defaulttvdbseason="0" episodeoffset="3" imdbid="tt0923811">
     <name>Evangelion Shin Gekijouban: Jo</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
@@ -12748,10 +12748,6 @@
   </anime>
   <anime anidbid="5101" tvdbid="80644" defaulttvdbseason="1">
     <name>Clannad</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="1">;1-23;</mapping>
-    </mapping-list>
-    <before>;1-23;</before>
   </anime>
   <anime anidbid="5104" tvdbid="79156" defaulttvdbseason="0" imdbid="tt1135522">
     <name>Shin Kyuuseishu Densetsu Hokuto no Ken Raou-den Gekitou no Shou</name>
@@ -14611,7 +14607,7 @@
       <mapping anidbseason="0" tvdbseason="0">;1-2;2-3;3-0;4-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="6171" tvdbid="70350" defaulttvdbseason="0" episodeoffset="3" imdbid="tt0860906">
+  <anime anidbid="6171" tvdbid="70350" defaulttvdbseason="0" episodeoffset="4" imdbid="tt0860906">
     <name>Evangelion Shin Gekijouban: Ha</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -15016,11 +15012,6 @@
   </anime>
   <anime anidbid="6367" tvdbid="79414" defaulttvdbseason="1">
     <name>Suzumiya Haruhi no Yuuutsu (2009)</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
-      <mapping anidbseason="1" tvdbseason="1">;1-2;2-3;3-5;4-10;5-13;6-14;7-4;9-7;10-6;11-8;25-1;26-12;27-11;28-9;</mapping>
-      <mapping anidbseason="1" tvdbseason="2">;8-1;12-2;13-3;14-4;15-5;16-6;17-7;18-8;19-9;20-10;21-11;22-12;23-13;24-14;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="6368" tvdbid="hentai" defaulttvdbseason="1">
     <name>Nudlnude</name>
@@ -17879,7 +17870,7 @@
   <anime anidbid="7564" tvdbid="164741" defaulttvdbseason="0" imdbid="unknown">
     <name>Ninja Hattori-kun: Nin Nin Ninpo Enikki no Maki</name>
   </anime>
-  <anime anidbid="7565" tvdbid="70350" defaulttvdbseason="0" episodeoffset="4" imdbid="tt0860907">
+  <anime anidbid="7565" tvdbid="70350" defaulttvdbseason="0" episodeoffset="5" imdbid="tt0860907">
     <name>Evangelion Shin Gekijouban: Q</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -25160,7 +25151,7 @@
   <anime anidbid="10936" tvdbid="289903" defaulttvdbseason="1">
     <name>Kyoukai no Rinne</name>
   </anime>
-  <anime anidbid="10937" tvdbid="328719" defaulttvdbseason="1" imdbid="tt5323662">
+  <anime anidbid="10937" tvdbid="movie" defaulttvdbseason="1" imdbid="tt5323662">
     <name>Eiga Koe no Katachi</name>
   </anime>
   <anime anidbid="10938" tvdbid="295243" defaulttvdbseason="1">
@@ -28215,6 +28206,9 @@
   <anime anidbid="13362" tvdbid="339276" defaulttvdbseason="1">
     <name>Hakumei to Mikochi</name>
   </anime>
+  <anime anidbid="13363" tvdbid="movie" defaulttvdbseason="1" imdbid="tt7236034">
+    <name>Kimi no Suizou o Tabetai</name>
+  </anime>
   <anime anidbid="13376" tvdbid="337015" defaulttvdbseason="1">
     <name>Takunomi.</name>
   </anime>
@@ -28274,6 +28268,12 @@
   </anime>
   <anime anidbid="13426" tvdbid="344222" defaulttvdbseason="1">
     <name>Uchuu Senkan Tiramisu</name>
+  </anime>
+  <anime anidbid="13430" tvdbid="305089" defaulttvdbseason="0">
+    <name>Re:Zero kara Hajimeru Isekai Seikatsu (2018)</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-26;2-28;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="13434" tvdbid="340011" defaulttvdbseason="1">
     <name>Hinamatsuri (2018)</name>


### PR DESCRIPTION
I think these updates are correct:

Based off https://thetvdb.com/series/neon-genesis-evangelion/seasons/official/0
Shinseiki Evangelion Gekijouban: Air / Magokoro o, Kimi ni - should map to season 0 episode 3

Evangelion Shin Gekijouban: Jo - should map to season 0 episode 4

Evangelion Shin Gekijouban: Ha - should map to season 0 episode 5

Evangelion Shin Gekijouban: Q - should map to season 0 episode 6

Haruhi - use 2009 series ordering rather than DVD
https://thetvdb.com/series/the-melancholy-of-haruhi-suzumiya/seasons/alternate/1

Clannad - first special should map to season 0 episode 1, rather than season 1 episode 23
https://thetvdb.com/series/clannad/seasons/official/0

Eiga Koe no Katachi is a movie and I'm not sure what tvdbid 328719 was supposed to be

Kimi no Suizou o Tabetai is a movie, added imdbid https://www.imdb.com/title/tt7236034/

https://anidb.net/anime/13430
https://thetvdb.com/series/re-zero-starting-life-in-another-world/seasons/official/0
Re:Zero kara Hajimeru Isekai Seikatsu (2018)

Memory Snow - should map to season 0 episode 26
The Frozen Bond - should map to season 0 episode 28
